### PR TITLE
Resolve "macOS: add openmpi/3.1.3 variant with clang-macos/10.0.1"

### DIFF
--- a/Compiler/openmpi/files/variants.Darwin
+++ b/Compiler/openmpi/files/variants.Darwin
@@ -24,3 +24,4 @@ openmpi/3.1.1	stable		gcc/7.3.0
 openmpi/3.1.2	stable		gcc/7.3.0
 openmpi/3.1.3	stable		gcc/7.3.0
 openmpi/3.1.3	unstable		clang-macos/10.0.1
+openmpi/4.0.1	unstable		clang-macos/10.0.1


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "macOS: add openmpi/3.1.3 varian...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/6) |
> | **GitLab MR Number** | [6](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/6) |
> | **Date Originally Opened** | Thu, 25 Apr 2019 |
> | **Date Originally Merged** | Thu, 25 Apr 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #7