### PR TITLE
Resolve "modules for mpich 3.3 with gcc/7.4.0 and gcc/8.3.0"

### DIFF
--- a/Compiler/mpich/files/variants
+++ b/Compiler/mpich/files/variants
@@ -8,3 +8,5 @@ mpich/3.2.1_merlin		unstable	gcc/7.3.0 b:binutils/2.29 b:mxm/3.6.3104
 mpich/3.2.1			stable		intel/17.4
 
 mpich/3.3			stable		gcc/7.3.0
+mpich/3.3			stable		gcc/7.4.0
+mpich/3.3			stable		gcc/8.3.0


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "modules for mpich 3.3 with gcc/...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/8) |
> | **GitLab MR Number** | [8](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/8) |
> | **Date Originally Opened** | Fri, 31 May 2019 |
> | **Date Originally Merged** | Fri, 31 May 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #9