### PR TITLE
Resolve "build module for Perl 5.8"

### DIFF
--- a/Programming/perl/files/variants
+++ b/Programming/perl/files/variants
@@ -1,2 +1,3 @@
+perl/5.10.1 	stable
 perl/5.26.1	stable
 perl/5.28.1	stable


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "build module for Perl 5.8"](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/9) |
> | **GitLab MR Number** | [9](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/9) |
> | **Date Originally Opened** | Fri, 12 Jul 2019 |
> | **Date Originally Merged** | Fri, 19 Jul 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

A user requested Perl version 5.8 or 5.10. Version 5.8 did not compile out of the box. There were no such problems with 5.10. So a module for Perl 5.10.1 has been build.

Closes #10