### PR TITLE
Resolve "getopt module: group not set in build-script"

### DIFF
--- a/System/getopt/build
+++ b/System/getopt/build
@@ -2,8 +2,7 @@
 
 pbuild::set_download_url "http://frodo.looijaard.name/system/files/software/$P/$P-${V_PKG}.tar.gz"
 pbuild::compile_in_sourcetree
-
-module use System
+pbuild::add_to_group System
 
 pbuild::pre_configure_Linux() {
 	pbuild::add_patch "files/Makefile.patch"


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "getopt module: group not set in...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/23) |
> | **GitLab MR Number** | [23](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/23) |
> | **Date Originally Opened** | Fri, 23 Aug 2019 |
> | **Date Originally Merged** | Fri, 23 Aug 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #22