### PR TITLE
Deploy fftw/3.3.8-1

### DIFF
--- a/MPI/fftw/README
+++ b/MPI/fftw/README
@@ -2,6 +2,16 @@ FFTW
 ====
 
 FFTW is highly optimized, but downgrades if run on an older processor. It
-should be built compiled on a system with SSE2 and AVX2 support (e.g. merlin).
+should be built compiled on merlin, since it needs SSE2, AVX2, and Infiniband
+(libfabric).
 
 This module requires PMODULE_VERSION > 1.0.0 to compile.
+
+The module is currently organized around several use flags:
+
+- *sp* single precision vs *dp* double precision
+- *merlin6* vs *merlin*. These come from the upstream dependency on openmpi,
+  which needs to be compiled differently for RHEL6 (merlin) and RHEL7
+  (merlin6).
+
+

--- a/MPI/fftw/build
+++ b/MPI/fftw/build
@@ -3,7 +3,7 @@
 
 pbuild::add_to_group 'MPI'
 
-pbuild::set_download_url "http://www.fftw.org/fftw-$V.tar.gz"
+pbuild::set_download_url "http://www.fftw.org/fftw-${V_PKG}.tar.gz"
 pbuild::set_sha256sum "fftw-3.3.8.tar.gz:6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303"
 
 pbuild::install_docfiles 'COPYRIGHT' 'COPYING' 'README' 'NEWS'
@@ -22,4 +22,18 @@ pbuild::pre_configure() {
     # CPU optimizations
     pbuild::add_configure_args "--enable-sse2"
     pbuild::add_configure_args "--enable-avx2"
+    pbuild::add_configure_args "--with-pic"
+    #pbuild::add_configure_args "--enable-shared"
+
+    # Floating point precision
+    #pbuild::add_configure_args "--enable-type-prefix"
+    if pbuild::use_flag "sp"; then
+        pbuild::add_configure_args "--enable-single"
+        pbuild::add_configure_args "--enable-sse"
+    elif pbuild::use_flag "dp"; then
+        : #default
+    else
+        echo "No flag specified" >&2
+        exit 1
+    fi
 }

--- a/MPI/fftw/files/variants
+++ b/MPI/fftw/files/variants
@@ -1,1 +1,8 @@
-fftw/3.3.8	unstable	gcc/{7.3.0,8.2.0} mpich/3.2.1 openmpi/3.1.3
+fftw/3.3.8	deprecated	gcc/{7.3.0,8.2.0} mpich/3.2.1 openmpi/3.1.3
+# Use older MPI version on merlin5
+fftw/3.3.8-1_sp_merlin	unstable	gcc/8.2.0 mpich/3.2.1 openmpi/3.1.1
+fftw/3.3.8-1_dp_merlin	unstable	gcc/8.2.0 mpich/3.2.1 openmpi/3.1.1
+# Merlin6 mpi version
+fftw/3.3.8-1_sp_merlin6	unstable	gcc/{7.4.0,8.3.0} mpich/3.3 openmpi/3.1.4_merlin6
+fftw/3.3.8-1_dp_merlin6	unstable	gcc/{7.4.0,8.3.0} mpich/3.3 openmpi/3.1.4_merlin6
+


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | bliven_s |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Deploy fftw/3.3.8-1](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/33) |
> | **GitLab MR Number** | [33](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/33) |
> | **Date Originally Opened** | Wed, 28 Aug 2019 |
> | **Date Originally Merged** | Thu, 26 Sep 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

- Single (sp) and double precision (dp) variants based on the use flags
- Add merlin & merlin6 flags to indicate that the software depends on
  merlin-specific architecture features (SSE and AVX)
- Depend on most recent OpenMPI compiled for merlin5/merlin6