### PR TITLE
Resolve "boost: cleanup variants files for RHEL6 and macOS10.14"

### DIFF
--- a/MPI/boost/files/variants.macos10.14
+++ b/MPI/boost/files/variants.macos10.14
@@ -1,0 +1,2 @@
+boost/1.70.0         unstable	gcc/8.3.0 openmpi/3.1.3 b:zlib/1.2.11
+

--- a/MPI/boost/files/variants.rhel6
+++ b/MPI/boost/files/variants.rhel6
@@ -1,16 +1,17 @@
-boost/1.66.0         unstable	gcc/7.3.0 openmpi/3.0.0 b:Python/2.7.14
+boost/1.66.0         stable	gcc/7.3.0 openmpi/3.0.0 b:Python/2.7.14
 
-boost/1.68.0         unstable	gcc/7.3.0 openmpi/1.10.7 b:Python/2.7.14
-boost/1.68.0         unstable	gcc/7.3.0 openmpi/2.1.5 b:Python/2.7.14
-boost/1.68.0         unstable	gcc/7.3.0 openmpi/3.0.0 b:Python/2.7.14
-boost/1.68.0         unstable	gcc/7.3.0 openmpi/3.1.2 b:Python/2.7.14
-boost/1.68.0         unstable	gcc/7.3.0 openmpi/3.1.3 b:Python/2.7.14
-boost/1.68.0-1       unstable	gcc/7.3.0 openmpi/3.1.3 b:zlib/1.2.11
+boost/1.68.0         stable	gcc/7.3.0 openmpi/1.10.7 b:Python/2.7.14
+boost/1.68.0         stable	gcc/7.3.0 openmpi/2.1.5 b:Python/2.7.14
+boost/1.68.0         stable	gcc/7.3.0 openmpi/3.0.0 b:Python/2.7.14
+boost/1.68.0         stable	gcc/7.3.0 openmpi/3.1.2 b:Python/2.7.14
+boost/1.68.0         stable	gcc/7.3.0 openmpi/3.1.3 b:Python/2.7.14
+boost/1.68.0-1       stable	gcc/7.3.0 openmpi/3.1.3 b:zlib/1.2.11
+boost/1.70.0         unstable	gcc/7.3.0 openmpi/3.1.3 b:zlib/1.2.11
 
-boost/1.68.0         unstable	gcc/8.2.0 openmpi/1.10.7 b:Python/2.7.14
-boost/1.68.0         unstable	gcc/8.2.0 openmpi/2.1.5 b:Python/2.7.14
-boost/1.68.0         unstable	gcc/8.2.0 openmpi/3.0.0 b:Python/2.7.14
-boost/1.68.0         unstable	gcc/8.2.0 openmpi/3.1.2 b:Python/2.7.14
-boost/1.68.0         unstable	gcc/8.2.0 openmpi/3.1.3 b:Python/2.7.14
+boost/1.68.0         stable	gcc/8.2.0 openmpi/1.10.7 b:Python/2.7.14
+boost/1.68.0         stable	gcc/8.2.0 openmpi/2.1.5 b:Python/2.7.14
+boost/1.68.0         stable	gcc/8.2.0 openmpi/3.0.0 b:Python/2.7.14
+boost/1.68.0         stable	gcc/8.2.0 openmpi/3.1.2 b:Python/2.7.14
+boost/1.68.0         stable	gcc/8.2.0 openmpi/3.1.3 b:Python/2.7.14
 
-boost/1.68.0-1       unstable	gcc/7.3.0 mpich/3.3 b:zlib/1.2.11
+boost/1.68.0-1       stable	gcc/7.3.0 mpich/3.3 b:zlib/1.2.11


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "boost: cleanup variants files f...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/47) |
> | **GitLab MR Number** | [47](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/47) |
> | **Date Originally Opened** | Thu, 12 Sep 2019 |
> | **Date Originally Merged** | Thu, 12 Sep 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #41