### PR TITLE
Resolve "OPAL: cleanup variants for Linux/RHEL6"

### DIFF
--- a/MPI/OPAL/2/variants
+++ b/MPI/OPAL/2/variants
@@ -1,3 +1,0 @@
-OPAL/2.0.0rc2	deprecated	gcc/7.3.0 openmpi/3.0.0 boost/1.66.0 hdf5/1.10.1 H5hut/2.0.0rc4 gsl/2.4 trilinos/12.12.1 b:cmake/3.9.6 b:OpenBLAS/0.2.20
-OPAL/2.0.1	stable		gcc/7.3.0 openmpi/3.1.3 boost/1.68.0 hdf5/1.10.4 H5hut/2.0.0rc5 gsl/2.5 trilinos/12.12.1 b:cmake/3.9.6 b:OpenBLAS/0.2.20
-OPAL/2.0.2	stable		gcc/7.3.0 openmpi/3.1.3 boost/1.68.0 hdf5/1.10.4 H5hut/2.0.0rc5 gsl/2.5 trilinos/12.12.1 b:cmake/3.9.6 b:OpenBLAS/0.2.20

--- a/MPI/OPAL/files/variants.rhel6
+++ b/MPI/OPAL/files/variants.rhel6
@@ -2,7 +2,6 @@ OPAL/1.3.0		deprecated	gcc/4.8.3 openmpi/1.8.2
 OPAL/1.3.1		deprecated	gcc/4.8.3 openmpi/1.8.2
 OPAL/1.3.2		stable		gcc/4.8.3 openmpi/1.8.2
 OPAL/1.4.0		stable		gcc/4.8.3 openmpi/1.8.2
-OPAL/1.4.0rc1		removed		gcc/4.8.3 openmpi/1.8.2
 OPAL/1.4.0rc2		deprecated	gcc/4.8.3 openmpi/1.8.2
 OPAL/1.4.0rc3		deprecated	gcc/4.8.3 openmpi/1.8.2
 OPAL/1.5.0-20161209	deprecated	gcc/5.4.0 openmpi/1.10.4
@@ -20,3 +19,5 @@ OPAL/1.6.0rc6		deprecated	gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hu
 OPAL/1.6.0		stable		gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
 OPAL/1.6.1		stable		gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
 OPAL/1.6.2		stable		gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
+OPAL/2.0.0rc2		deprecated	gcc/7.3.0 openmpi/3.0.0 boost/1.66.0 hdf5/1.10.1 H5hut/2.0.0rc4 gsl/2.4 trilinos/12.12.1 b:cmake/3.9.6 b:OpenBLAS/0.2.20
+OPAL/2.0.2		unstable	gcc/7.3.0 openmpi/3.1.3 boost/1.68.0 hdf5/1.10.4 H5hut/2.0.0rc5 gsl/2.5 trilinos/12.12.1 b:cmake/3.9.6 b:OpenBLAS/0.2.20


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "OPAL: cleanup variants for Linu...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/48) |
> | **GitLab MR Number** | [48](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/48) |
> | **Date Originally Opened** | Thu, 12 Sep 2019 |
> | **Date Originally Merged** | Thu, 12 Sep 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #42