### PR TITLE
Resolve "gsl: build version 2.6 with current gcc versions"

### DIFF
--- a/Compiler/gsl/files/variants.rhel6
+++ b/Compiler/gsl/files/variants.rhel6
@@ -1,33 +1,15 @@
-gsl/1.15             stable     gcc/4.7.4 
-gsl/1.15             stable     gcc/4.8.3 
-gsl/1.15             stable     gcc/4.8.4 
-gsl/1.15             stable     gcc/4.8.5 
-gsl/1.15             deprecated gcc/4.9.2 
-gsl/1.15             stable     gcc/4.9.3 
-gsl/1.15             stable     gcc/4.9.4 
-gsl/1.15             stable     gcc/5.3.0 
-gsl/1.15             stable     gcc/5.4.0 
-gsl/1.15             stable	gcc/6.2.0 
+gsl/1.15	stable		gcc/{4.7.4,4.8.3,4.8.4,4.8.5,4.9.3,4.9.4}
+gsl/1.15	deprecated	gcc/4.9.2 
+gsl/1.15	stable		gcc/{5.3.0,5.4.0,6.2.0}
 
-gsl/1.16             stable	gcc/4.8.5 
-gsl/1.16             stable	gcc/4.9.4 
-gsl/1.16             stable	gcc/5.4.0 
-gsl/1.16             stable	gcc/6.2.0 
-gsl/2.2.1       stable		gcc/4.8.5 
-gsl/2.2.1       stable		gcc/4.9.4 
-gsl/2.2.1       stable		gcc/5.4.0 
-gsl/2.2.1       stable		gcc/6.2.0 
-gsl/2.2.1       stable		gcc/6.3.0 
+gsl/1.16	stable		gcc/{4.8.5,4.9.4,5.4.0,6.2.0} 
+gsl/2.2.1       stable		gcc/{4.8.5,4.9.4,5.4.0,6.2.0,6.3.0} 
 
-gsl/2.4		stable		gcc/5.5.0 
-gsl/2.4		stable		gcc/6.4.0 
-gsl/2.4		stable		gcc/7.3.0 
+gsl/2.4		stable		gcc/{5.5.0,6.4.0,7.3.0} 
 gsl/2.4		stable		clang-macos/9.0.0
 gsl/2.4		stable		intel/17.4
 
-gsl/2.5		stable		gcc/6.3.0 
-gsl/2.5		stable		gcc/7.3.0 
-gsl/2.5		stable		gcc/7.4.0 
-gsl/2.5		stable		gcc/8.3.0 
-gsl/2.5		stable		gcc/9.1.0 
+gsl/2.5		stable		gcc/{6.3.0,7.3.0,7.4.0,8.3.0,9.1.0} 
 gsl/2.5		stable		intel/19.4 
+
+gsl/2.6		stable		gcc/{7.4.0,8.3.0,9.1.0,9.2.0}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "gsl: build version 2.6 with cur...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/71) |
> | **GitLab MR Number** | [71](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/71) |
> | **Date Originally Opened** | Tue, 5 Nov 2019 |
> | **Date Originally Merged** | Tue, 5 Nov 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #57