### PR TITLE
Resolve "amex: release modules as stable"

### DIFF
--- a/MPI/amrex/files/variants
+++ b/MPI/amrex/files/variants
@@ -1,29 +1,29 @@
-amrex/18.07_2d	unstable	gcc/7.3.0 openmpi/1.10.7 b:cmake/3.9.6
-amrex/18.07_2d	unstable	gcc/7.3.0 openmpi/2.1.5 b:cmake/3.9.6
-amrex/18.07_2d	unstable	gcc/7.3.0 openmpi/3.0.0 b:cmake/3.9.6
-amrex/18.07_2d	unstable	gcc/7.3.0 openmpi/3.1.2 b:cmake/3.9.6
-amrex/18.07_2d	unstable	gcc/7.3.0 openmpi/3.1.3 b:cmake/3.9.6
+amrex/18.07_2d	stable		gcc/7.3.0 openmpi/1.10.7 b:cmake/3.9.6
+amrex/18.07_2d	stable		gcc/7.3.0 openmpi/2.1.5 b:cmake/3.9.6
+amrex/18.07_2d	stable		gcc/7.3.0 openmpi/3.0.0 b:cmake/3.9.6
+amrex/18.07_2d	stable		gcc/7.3.0 openmpi/3.1.2 b:cmake/3.9.6
+amrex/18.07_2d	stable		gcc/7.3.0 openmpi/3.1.3 b:cmake/3.9.6
 amrex/18.07_2d	stable		gcc/7.4.0 openmpi/3.1.4 b:cmake/3.10.3
 
-amrex/18.07_2d	unstable	gcc/8.2.0 openmpi/1.10.7 b:cmake/3.9.6
-amrex/18.07_2d	unstable	gcc/8.2.0 openmpi/2.1.5 b:cmake/3.9.6
-amrex/18.07_2d	unstable	gcc/8.2.0 openmpi/3.1.3 b:cmake/3.9.6
+amrex/18.07_2d	stable		gcc/8.2.0 openmpi/1.10.7 b:cmake/3.9.6
+amrex/18.07_2d	stable		gcc/8.2.0 openmpi/2.1.5 b:cmake/3.9.6
+amrex/18.07_2d	stable		gcc/8.2.0 openmpi/3.1.3 b:cmake/3.9.6
 
-amrex/18.07_2d	unstable	gcc/7.3.0 mpich/3.2.1 b:cmake/3.9.6
-amrex/18.07_2d	unstable	gcc/8.2.0 mpich/3.2.1 b:cmake/3.9.6
+amrex/18.07_2d	stable		gcc/7.3.0 mpich/3.2.1 b:cmake/3.9.6
+amrex/18.07_2d	stable		gcc/8.2.0 mpich/3.2.1 b:cmake/3.9.6
 
 
-amrex/18.07_3d	unstable	gcc/7.3.0 openmpi/1.10.7 b:cmake/3.9.6
-amrex/18.07_3d	unstable	gcc/7.3.0 openmpi/2.1.5 b:cmake/3.9.6
-amrex/18.07_3d	unstable	gcc/7.3.0 openmpi/3.0.0 b:cmake/3.9.6
-amrex/18.07_3d	unstable	gcc/7.3.0 openmpi/3.1.2 b:cmake/3.9.6
-amrex/18.07_3d	unstable	gcc/7.3.0 openmpi/3.1.3 b:cmake/3.9.6
+amrex/18.07_3d	stable		gcc/7.3.0 openmpi/1.10.7 b:cmake/3.9.6
+amrex/18.07_3d	stable		gcc/7.3.0 openmpi/2.1.5 b:cmake/3.9.6
+amrex/18.07_3d	stable		gcc/7.3.0 openmpi/3.0.0 b:cmake/3.9.6
+amrex/18.07_3d	stable		gcc/7.3.0 openmpi/3.1.2 b:cmake/3.9.6
+amrex/18.07_3d	stable		gcc/7.3.0 openmpi/3.1.3 b:cmake/3.9.6
 amrex/18.07_3d	stable		gcc/7.4.0 openmpi/3.1.4 b:cmake/3.10.3
 
-amrex/18.07_3d	unstable	gcc/8.2.0 openmpi/1.10.7 b:cmake/3.9.6
-amrex/18.07_3d	unstable	gcc/8.2.0 openmpi/2.1.5 b:cmake/3.9.6
-amrex/18.07_3d	unstable	gcc/8.2.0 openmpi/3.1.3 b:cmake/3.9.6
+amrex/18.07_3d	stable		gcc/8.2.0 openmpi/1.10.7 b:cmake/3.9.6
+amrex/18.07_3d	stable		gcc/8.2.0 openmpi/2.1.5 b:cmake/3.9.6
+amrex/18.07_3d	stable		gcc/8.2.0 openmpi/3.1.3 b:cmake/3.9.6
 
-amrex/18.07_3d	unstable	gcc/7.3.0 mpich/3.2.1 b:cmake/3.9.6
-amrex/18.07_3d	unstable	gcc/8.2.0 mpich/3.2.1 b:cmake/3.9.6
+amrex/18.07_3d	stable		gcc/7.3.0 mpich/3.2.1 b:cmake/3.9.6
+amrex/18.07_3d	stable		gcc/8.2.0 mpich/3.2.1 b:cmake/3.9.6
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "amex: release modules as stable...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/75) |
> | **GitLab MR Number** | [75](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/75) |
> | **Date Originally Opened** | Tue, 5 Nov 2019 |
> | **Date Originally Merged** | Tue, 5 Nov 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #61