### PR TITLE
Resolve "boost: build 1.70.0 with gcc/7.4.0 openmpi/3.1.4"

### DIFF
--- a/MPI/boost/files/variants.rhel6
+++ b/MPI/boost/files/variants.rhel6
@@ -9,10 +9,10 @@ boost/1.68.0-1       stable	gcc/7.3.0 openmpi/3.1.3 b:zlib/1.2.11
 
 boost/1.68.0         stable	gcc/8.2.0 openmpi/1.10.7 b:Python/2.7.14
 boost/1.68.0         stable	gcc/8.2.0 openmpi/2.1.5 b:Python/2.7.14
-boost/1.68.0         stable	gcc/8.2.0 openmpi/3.0.0 b:Python/2.7.14
 boost/1.68.0         stable	gcc/8.2.0 openmpi/3.1.2 b:Python/2.7.14
 boost/1.68.0         stable	gcc/8.2.0 openmpi/3.1.3 b:Python/2.7.14
 
 boost/1.68.0-1       stable	gcc/7.3.0 mpich/3.3 b:zlib/1.2.11
 
 boost/1.70.0         stable	gcc/7.3.0 openmpi/3.1.3 b:zlib/1.2.11
+boost/1.70.0         stable	gcc/7.4.0 openmpi/3.1.4 b:zlib/1.2.11


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "boost: build 1.70.0 with gcc/7....](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/77) |
> | **GitLab MR Number** | [77](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/77) |
> | **Date Originally Opened** | Tue, 5 Nov 2019 |
> | **Date Originally Merged** | Tue, 5 Nov 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #63