### PR TITLE
Resolve "hdf5/1.10.6: build with current GCCs and openmpi for rhel6 and merlin6"

### DIFF
--- a/MPI/hdf5/build
+++ b/MPI/hdf5/build
@@ -1,6 +1,6 @@
 #!/usr/bin/env modbuild
 
-pbuild::set_download_url "https://support.hdfgroup.org/ftp/HDF5/releases/$P-${V_MAJOR}.${V_MINOR}/$P-$V/src/hdf5-$V.tar.bz2"
+pbuild::set_download_url "https://support.hdfgroup.org/ftp/HDF5/releases/$P-${V_MAJOR}.${V_MINOR}/$P-$V/src/hdf5-${V_PKG}.tar.bz2"
 pbuild::add_to_group 'MPI'
 
 pbuild::install_docfiles ACKNOWLEDGMENTS

--- a/MPI/hdf5/files/variants.merlin6
+++ b/MPI/hdf5/files/variants.merlin6
@@ -1,0 +1,2 @@
+hdf5/1.10.6_slurm	unstable	gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6_slurm
+

--- a/MPI/hdf5/files/variants.rhel6
+++ b/MPI/hdf5/files/variants.rhel6
@@ -37,3 +37,4 @@ hdf5/1.10.4 	stable    	gcc/{5.5.0,6.4.0,7.3.0,8.2.0} openmpi/3.1.3
 hdf5/1.10.4 	stable    	gcc/7.3.0 mpich/3.3
 
 hdf5/1.10.5	stable		gcc/{7.4.0,8.3.0} openmpi/3.1.4
+hdf5/1.10.6	unstable	gcc/{7.5.0,8.4.0,9.3.0,10.1.0} openmpi/3.1.6


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "hdf5/1.10.6: build with current...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/108) |
> | **GitLab MR Number** | [108](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/108) |
> | **Date Originally Opened** | Thu, 16 Jul 2020 |
> | **Date Originally Merged** | Thu, 16 Jul 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #85