### PR TITLE
Resolve "parmetis/4.0.3: build with current GCCs and openmpi"

### DIFF
--- a/MPI/parmetis/files/variants.merlin6
+++ b/MPI/parmetis/files/variants.merlin6
@@ -1,0 +1,2 @@
+parmetis/4.0.3_slurm	unstable	gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6_slurm b:cmake/3.15.5
+

--- a/MPI/parmetis/files/variants.rhel6
+++ b/MPI/parmetis/files/variants.rhel6
@@ -1,31 +1,25 @@
+parmetis/3.2.0	stable		gcc/{4.7.4,4.8.3,4.8.4,4.9.2} openmpi/{1.6.5,1.8.2,1.8.4}
+
+parmetis/3.2.0	stable		gcc/{4.7.4,4.8.5,4.9.3,5.3.0,6.1.0} openmpi/1.8.8
+
+parmetis/3.2.0	stable		gcc/{4.8.5,5.3.0,6.1.0,6.2.0} openmpi/1.10.2
+
+parmetis/3.2.0	stable		gcc/6.2.0 openmpi/{1.10.4,2.0.1}
+
+parmetis/3.2.0	stable		gcc/7.3.0 openmpi/3.0.1
+
 parmetis/4.0.3	stable		gcc/4.8.2 openmpi/1.6.5  b:cmake/3.4.1
-parmetis/4.0.3	stable		gcc/4.8.5 openmpi/1.10.2 b:cmake/3.4.1
-parmetis/4.0.3	stable		gcc/4.9.4 openmpi/1.10.2 b:cmake/3.4.1
-parmetis/4.0.3	stable		gcc/5.3.0 openmpi/1.10.2 b:cmake/3.4.1
-parmetis/4.0.3	stable		gcc/5.4.0 openmpi/1.10.2 b:cmake/3.4.1
-parmetis/4.0.3	stable		gcc/6.1.0 openmpi/1.10.2 b:cmake/3.4.1
-parmetis/4.0.3	stable		gcc/6.2.0 openmpi/1.10.2 b:cmake/3.4.1
+parmetis/4.0.3	stable		gcc/{4.8.5,4.9.4,5.3.0,5.4.0,6.1.0,6.2.0} openmpi/1.10.2 b:cmake/3.4.1
 
-parmetis/4.0.3	unstable	gcc/4.8.5 openmpi/1.10.4 b:cmake/3.6.3
-parmetis/4.0.3	unstable	gcc/4.9.4 openmpi/1.10.4 b:cmake/3.6.3
-parmetis/4.0.3	unstable	gcc/5.4.0 openmpi/1.10.4 b:cmake/3.6.3
-parmetis/4.0.3	unstable	gcc/6.2.0 openmpi/1.10.4 b:cmake/3.6.3
+parmetis/4.0.3	stable		gcc/{4.8.5,4.9.4,5.4.0,6.2.0} openmpi/1.10.4 b:cmake/3.6.3
 
-parmetis/4.0.3	unstable	gcc/6.2.0 openmpi/2.0.1  b:cmake/3.6.3
+parmetis/4.0.3	stable		gcc/6.2.0 openmpi/2.0.1  b:cmake/3.6.3
 
-parmetis/4.0.3	stable		gcc/7.3.0 openmpi/1.10.7 b:cmake/3.6.3
-parmetis/4.0.3	stable		gcc/7.3.0 openmpi/2.1.2  b:cmake/3.6.3
-parmetis/4.0.3	stable		gcc/7.3.0 openmpi/3.0.0  b:cmake/3.6.3
-parmetis/4.0.3	stable		gcc/7.3.0 openmpi/3.0.1  b:cmake/3.9.6
-parmetis/4.0.3	stable		gcc/7.3.0 openmpi/3.1.2  b:cmake/3.9.6
-parmetis/4.0.3	stable		gcc/7.3.0 openmpi/3.1.3  b:cmake/3.9.6
+parmetis/4.0.3	stable		gcc/7.3.0 openmpi/{1.10.7,2.1.2,3.0.0,3.0.1,3.1.2,3.1.3} b:cmake/3.6.3
 parmetis/4.0.3	stable		gcc/7.4.0 openmpi/3.1.4  b:cmake/3.9.6
-parmetis/4.0.3	stable		clang-macos/9.0.0 openmpi/1.10.7 b:cmake/3.6.3
-parmetis/4.0.3	stable		clang-macos/9.0.0 openmpi/2.1.2  b:cmake/3.6.3
-parmetis/4.0.3	stable		clang-macos/9.0.0 openmpi/3.0.0  b:cmake/3.6.3
 
-parmetis/4.0.3	stable		intel/17.4 openmpi/1.10.7 b:cmake/3.6.3
-parmetis/4.0.3	stable		intel/17.4 openmpi/2.1.2  b:cmake/3.6.3
-parmetis/4.0.3	stable		intel/17.4 openmpi/3.0.0  b:cmake/3.6.3
+parmetis/4.0.3	stable		intel/17.4 openmpi/{1.10.7,2.1.2,3.0.0} b:cmake/3.6.3
 
 parmetis/4.0.3	stable		gcc/7.3.0 mpich/3.3  b:cmake/3.9.6
+
+parmetis/4.0.3	unstable	gcc/{7.5.0,8.4.0,9.3.0,10.1.0} openmpi/3.1.6 b:cmake/3.9.6


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "parmetis/4.0.3: build with curr...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/109) |
> | **GitLab MR Number** | [109](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/109) |
> | **Date Originally Opened** | Thu, 16 Jul 2020 |
> | **Date Originally Merged** | Thu, 16 Jul 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #86