### PR TITLE
Resolve "H5hut: release 2.0.0rc6 parallel as stable"

### DIFF
--- a/HDF5/H5hut/files/variants.merlin6
+++ b/HDF5/H5hut/files/variants.merlin6
@@ -1,2 +1,2 @@
-H5hut/2.0.0rc6_slurm	unstable	gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6_slurm  hdf5/1.10.6_slurm b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3_slurm
+H5hut/2.0.0rc6_slurm	stable	gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6_slurm  hdf5/1.10.6_slurm b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3_slurm
 

--- a/HDF5/H5hut/files/variants.rhel6
+++ b/HDF5/H5hut/files/variants.rhel6
@@ -21,5 +21,5 @@ H5hut/2.0.0rc5	stable		gcc/7.3.0 openmpi/3.1.3  hdf5/1.10.4 b:automake/1.16.1 b:
 
 H5hut/2.0.0rc6	stable		gcc/7.3.0 openmpi/3.1.3  hdf5/1.10.4 b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3
 H5hut/2.0.0rc6	stable		gcc/7.4.0 openmpi/3.1.4  hdf5/1.10.5 b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3
-H5hut/2.0.0rc6	unstable	gcc/{7.5.0,8.4.0,9.3.0,10.1.0} openmpi/3.1.6  hdf5/1.10.6 b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3
+H5hut/2.0.0rc6	stable		gcc/{7.5.0,8.4.0,9.3.0,10.1.0} openmpi/3.1.6  hdf5/1.10.6 b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "H5hut: release 2.0.0rc6 paralle...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/137) |
> | **GitLab MR Number** | [137](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/137) |
> | **Date Originally Opened** | Mon, 16 Nov 2020 |
> | **Date Originally Merged** | Mon, 16 Nov 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #102