### PR TITLE
Resolve "hdf5: release version 1.10.6 parallel as stable"

### DIFF
--- a/MPI/hdf5/files/variants.merlin6
+++ b/MPI/hdf5/files/variants.merlin6
@@ -1,2 +1,2 @@
-hdf5/1.10.6_slurm	unstable	gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6_slurm
+hdf5/1.10.6_slurm	stable	gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6_slurm
 

--- a/MPI/hdf5/files/variants.rhel6
+++ b/MPI/hdf5/files/variants.rhel6
@@ -37,4 +37,4 @@ hdf5/1.10.4 	stable    	gcc/{5.5.0,6.4.0,7.3.0,8.2.0} openmpi/3.1.3
 hdf5/1.10.4 	stable    	gcc/7.3.0 mpich/3.3
 
 hdf5/1.10.5	stable		gcc/{7.4.0,8.3.0} openmpi/3.1.4
-hdf5/1.10.6	unstable	gcc/{7.5.0,8.4.0,9.3.0,10.1.0} openmpi/3.1.6
+hdf5/1.10.6	stable		gcc/{7.5.0,8.4.0,9.3.0,10.1.0} openmpi/3.1.6


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "hdf5: release version 1.10.6 pa...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/143) |
> | **GitLab MR Number** | [143](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/143) |
> | **Date Originally Opened** | Mon, 16 Nov 2020 |
> | **Date Originally Merged** | Mon, 16 Nov 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #108