### PR TITLE
Resolve "amrex/18.07_3d: release as stable"

### DIFF
--- a/MPI/amrex/files/variants.merlin6
+++ b/MPI/amrex/files/variants.merlin6
@@ -1,2 +1,2 @@
-amrex/18.07_3d_slurm	unstable	gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6_slurm b:cmake/3.15.5
+amrex/18.07_3d_slurm	stable	gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6_slurm b:cmake/3.15.5
 

--- a/MPI/amrex/files/variants.rhel6
+++ b/MPI/amrex/files/variants.rhel6
@@ -11,5 +11,5 @@ amrex/18.07_3d	stable		gcc/7.4.0 openmpi/3.1.4 b:cmake/3.10.3
 amrex/18.07_3d	stable		gcc/8.2.0 openmpi/{1.10.7,2.1.5,3.1.3} b:cmake/3.9.6
 amrex/18.07_3d	stable		gcc/{7.3.0,8.2.0} mpich/3.2.1 b:cmake/3.9.6
 
-amrex/18.07_3d	unstable	gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6 b:cmake/3.15.5
+amrex/18.07_3d	stable		gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6 b:cmake/3.15.5
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "amrex/18.07_3d: release as stab...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/145) |
> | **GitLab MR Number** | [145](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/145) |
> | **Date Originally Opened** | Mon, 16 Nov 2020 |
> | **Date Originally Merged** | Mon, 16 Nov 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #110