### PR TITLE
Resolve "parmetis: deprecate all modules build with openmpi 1 or 2"

### DIFF
--- a/MPI/parmetis/files/variants.rhel6
+++ b/MPI/parmetis/files/variants.rhel6
@@ -1,24 +1,24 @@
-parmetis/3.2.0	stable		gcc/{4.7.4,4.8.3,4.8.4,4.9.2} openmpi/{1.6.5,1.8.2,1.8.4}
+parmetis/3.2.0	deprecated	gcc/{4.7.4,4.8.3,4.8.4,4.9.2} openmpi/{1.6.5,1.8.2,1.8.4}
 
-parmetis/3.2.0	stable		gcc/{4.7.4,4.8.5,4.9.3,5.3.0,6.1.0} openmpi/1.8.8
+parmetis/3.2.0	deprecated	gcc/{4.8.5,5.3.0,6.1.0,6.2.0} openmpi/1.10.2
 
-parmetis/3.2.0	stable		gcc/{4.8.5,5.3.0,6.1.0,6.2.0} openmpi/1.10.2
+parmetis/3.2.0	deprecated	gcc/6.2.0 openmpi/{1.10.4,2.0.1}
 
-parmetis/3.2.0	stable		gcc/6.2.0 openmpi/{1.10.4,2.0.1}
+parmetis/3.2.0	deprecated	gcc/7.3.0 openmpi/3.0.1
 
-parmetis/3.2.0	stable		gcc/7.3.0 openmpi/3.0.1
+parmetis/3.2.0	deprecated	intel/15.3 openmpi/1.8.4
 
-parmetis/4.0.3	stable		gcc/4.8.2 openmpi/1.6.5  b:cmake/3.4.1
-parmetis/4.0.3	stable		gcc/{4.8.5,4.9.4,5.3.0,5.4.0,6.1.0,6.2.0} openmpi/1.10.2 b:cmake/3.4.1
+parmetis/4.0.3	deprecated	gcc/4.8.2 openmpi/1.6.5  b:cmake/3.4.1
+parmetis/4.0.3	deprecated	gcc/{4.8.5,4.9.4,5.3.0,5.4.0,6.1.0,6.2.0} openmpi/1.10.2 b:cmake/3.4.1
 
-parmetis/4.0.3	stable		gcc/{4.8.5,4.9.4,5.4.0,6.2.0} openmpi/1.10.4 b:cmake/3.6.3
+parmetis/4.0.3	deprecated	gcc/{4.8.5,4.9.4,5.4.0,6.2.0} openmpi/1.10.4 b:cmake/3.6.3
 
-parmetis/4.0.3	stable		gcc/6.2.0 openmpi/2.0.1  b:cmake/3.6.3
+parmetis/4.0.3	deprecated	gcc/6.2.0 openmpi/2.0.1  b:cmake/3.6.3
 
-parmetis/4.0.3	stable		gcc/7.3.0 openmpi/{1.10.7,2.1.2,3.0.0,3.0.1,3.1.2,3.1.3} b:cmake/3.6.3
-parmetis/4.0.3	stable		gcc/7.4.0 openmpi/3.1.4  b:cmake/3.9.6
+parmetis/4.0.3	deprecated	gcc/7.3.0 openmpi/{1.10.7,2.1.2,3.0.0,3.0.1,3.1.2,3.1.3} b:cmake/3.6.3
+parmetis/4.0.3	deprecated	gcc/7.4.0 openmpi/3.1.4  b:cmake/3.9.6
 
-parmetis/4.0.3	stable		intel/17.4 openmpi/{1.10.7,2.1.2,3.0.0} b:cmake/3.6.3
+parmetis/4.0.3	deprecated	intel/17.4 openmpi/{1.10.7,2.1.2,3.0.0} b:cmake/3.6.3
 
 parmetis/4.0.3	stable		gcc/7.3.0 mpich/3.3  b:cmake/3.9.6
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "parmetis: deprecate all modules...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/169) |
> | **GitLab MR Number** | [169](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/169) |
> | **Date Originally Opened** | Mon, 1 Mar 2021 |
> | **Date Originally Merged** | Mon, 1 Mar 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #125