### PR TITLE
Resolve "hdf5: deprecate all variants build with openmpi <= 3.1.5"

### DIFF
--- a/MPI/hdf5/files/variants.rhel6
+++ b/MPI/hdf5/files/variants.rhel6
@@ -1,44 +1,59 @@
-hdf5/1.8.12	stable		gcc/{4.7.4,4.8.3,4.8.4} openmpi/{1.6.5,1.8.2,1.8.4}
+hdf5/1.8.12	deprecated	gcc/{4.7.4,4.8.3,4.8.4,5.1.0} openmpi/{1.6.5,1.8.2,1.8.4}
 
-hdf5/1.8.12	stable		gcc/4.8.5 openmpi/1.8.8
+hdf5/1.8.12	deprecated	gcc/4.8.5 openmpi/1.8.8
 hdf5/1.8.12	deprecated	gcc/4.9.2 openmpi/{1.6.5,1.8.2,1.8.4}
 
-hdf5/1.8.14	stable		gcc/{4.7.4,4.8.3,4.8.4} openmpi/{1.6.5,1.8.2,1.8.4}
-hdf5/1.8.14	stable		gcc/4.8.4 openmpi/1.8.8
+hdf5/1.8.12	deprecated	intel/15.2 openmpi/1.6.5
+hdf5/1.8.12	deprecated	intel/{15.2,15.3} openmpi/1.8.4
+
+hdf5/1.8.13	deprecated	gcc/{4.7.4,4.8.3,4.8.4,4.9.2} openmpi/{1.6.5,1.8.2,1.8.4}
+
+hdf5/1.8.14	deprecated	gcc/{4.7.4,4.8.3,4.8.4} openmpi/{1.6.5,1.8.2,1.8.4}
 
 hdf5/1.8.14	deprecated	gcc/4.9.2 openmpi/{1.6.5,1.8.2,1.8.4}
 
-hdf5/1.8.15.1	deprecated	gcc/5.2.0 openmpi/1.8.8
+hdf5/1.8.14	deprecated	gcc/5.1.0 openmpi/{1.6.5,1.8.4}
+hdf5/1.8.14	deprecated	intel/15.2 openmpi/1.6.5
+hdf5/1.8.14	deprecated	intel/{15.2,15.3} openmpi/1.8.4
 
-hdf5/1.8.16	stable		gcc/{4.8.5,4.9.3,5.3.0,6.1.0} openmpi/{1.8.8,1.10.2}
+hdf5/1.8.15-patch1	deprecated	gcc/{4.7.4,4.8.4,4.9.2,5.1.0} openmpi/{1.6.5,1.8.4}
+hdf5/1.8.15-patch1	deprecated	gcc/{4.8.5,4.9.3} openmpi/1.10.0
+hdf5/1.8.15-patch1	deprecated	gcc/5.2.0 openmpi/1.10.0
+hdf5/1.8.15-patch1	deprecated	intel/15.3 openmpi/{1.6.5,1.8.4}
 
-hdf5/1.8.17	stable		gcc/{4.8.5,4.9.3,5.3.0,6.1.0} openmpi/{1.8.8,1.10.2}
-hdf5/1.8.17	stable		gcc/6.2.0 openmpi/1.10.2
-hdf5/1.8.17	stable		gcc/{4.8.5,4.9.4,5.4.0,6.2.0} openmpi/1.10.4
+hdf5/1.8.15.1	deprecated	gcc/{4.9.3,5.2.0} openmpi/1.8.8
 
-hdf5/1.8.18	stable		gcc/{4.8.5,4.9.4,5.4.0,6.2.0} openmpi/1.10.4
-hdf5/1.8.20	stable		gcc/{4.8.5,5.5.0,6.4.0,7.3.0,8.2.0} openmpi/{1.10.4,1.10.7,2.1.5,3.1.3,3.2.1}
-hdf5/1.8.20	stable		intel/18.4 impi/18.4
+hdf5/1.8.16	deprecated	gcc/4.8.5 openmpi/{1.8.8,1.10.2}
+hdf5/1.8.16	deprecated	gcc/4.9.2 openmpi/1.8.4
+hdf5/1.8.16	deprecated	gcc/4.9.3 openmpi/1.8.8
+hdf5/1.8.16	deprecated	gcc/{5.3.0,6.1.0} openmpi/1.10.2
 
-hdf5/1.10.0	stable		gcc/{4.8.5,5.3.0,6.1.0} openmpi/1.10.2
-hdf5/1.10.0	stable		gcc/5.3.0 openmpi/1.10.2
-hdf5/1.10.0	stable		gcc/6.1.0 openmpi/1.10.2
+hdf5/1.8.17	deprecated	 gcc/{4.8.5,4.9.4,5.4.0,6.2.0} openmpi/1.10.4
+hdf5/1.8.17	deprecated	 gcc/{5.3.0,6.1.0,6.2.0} openmpi/1.10.2
 
-hdf5/1.10.1	stable		gcc/7.3.0 openmpi/{1.10.7,2.1.2,3.0.0,3.0.1}
-hdf5/1.10.1	stable		intel/17.4 openmpi/{1.10.7,2.1.2,3.0.0}
-hdf5/1.10.1	stable		pgi/18.5 pgi-mpi/18.5
+hdf5/1.8.18	deprecated	gcc/{4.8.5,4.9.4,5.4.0,6.2.0} openmpi/1.10.4
 
-hdf5/1.10.2 	stable    	gcc/7.3.0 openmpi/3.0.1
+hdf5/1.8.20	deprecated	gcc/4.8.5 openmpi/1.10.4
+hdf5/1.8.20	deprecated	gcc/7.3.0 openmpi/{1.10.7,2.1.5}
 
-hdf5/1.10.3 	stable    	gcc/7.3.0 openmpi/3.1.2
-hdf5/1.10.3	stable		intel/17.4 intel-mpi/17.4
+hdf5/1.10.0	deprecated	gcc/{4.8.5,5.3.0,6.1.0} openmpi/1.10.2
 
-hdf5/1.10.4 	stable    	gcc/{5.5.0,6.4.0,7.3.0,8.2.0} openmpi/3.1.3
+hdf5/1.10.1	deprecated	gcc/7.3.0 openmpi/{1.10.7,2.1.2,3.0.0,3.0.1}
+hdf5/1.10.1	deprecated	intel/17.4 openmpi/{1.10.7,2.1.2,3.0.0}
+hdf5/1.10.1	deprecated	pgi/18.5 pgi-mpi/18.5
+
+hdf5/1.10.2 	deprecated    	gcc/7.3.0 openmpi/3.0.1
+
+hdf5/1.10.3 	deprecated	gcc/7.3.0 openmpi/3.1.2
+hdf5/1.10.3	deprecated	intel/17.4 intel-mpi/17.4
+
+hdf5/1.10.4 	deprecated    	gcc/{5.5.0,7.3.0,8.2.0} openmpi/3.1.3
 hdf5/1.10.4 	stable    	gcc/7.3.0 mpich/3.3
 
-hdf5/1.10.5	stable		gcc/{7.4.0,8.3.0} openmpi/3.1.4
+hdf5/1.10.5	deprecated	gcc/{7.4.0,8.3.0} openmpi/3.1.4
+
 hdf5/1.10.6	stable		gcc/{7.5.0,8.4.0,9.3.0,10.1.0} openmpi/3.1.6
 
-hdf5/1.10.7	unstable	gcc/{7.5.0,8.4.0,9.3.0,10.2.0} openmpi/4.0.5
+hdf5/1.10.7	stable		gcc/{7.5.0,8.4.0,9.3.0,10.2.0} openmpi/4.0.5
 
-hdf5/1.12.0	unstable	gcc/{7.5.0,8.4.0,9.3.0,10.2.0} openmpi/4.0.5
+hdf5/1.12.0	stable		gcc/{7.5.0,8.4.0,9.3.0,10.2.0} openmpi/4.0.5


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "hdf5: deprecate all variants bu...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/176) |
> | **GitLab MR Number** | [176](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/176) |
> | **Date Originally Opened** | Mon, 1 Mar 2021 |
> | **Date Originally Merged** | Tue, 2 Mar 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #130