### PR TITLE
Resolve "boost: deprecate variants build with openmpi <= 3.1.5"

### DIFF
--- a/MPI/boost/files/variants.rhel6
+++ b/MPI/boost/files/variants.rhel6
@@ -1,21 +1,13 @@
-boost/1.66.0         stable	gcc/7.3.0 openmpi/3.0.0 b:Python/2.7.14
+boost/1.66.0	deprecated	gcc/7.3.0 openmpi/3.0.0
 
-boost/1.68.0         stable	gcc/7.3.0 openmpi/1.10.7 b:Python/2.7.14
-boost/1.68.0         stable	gcc/7.3.0 openmpi/2.1.5 b:Python/2.7.14
-boost/1.68.0         stable	gcc/7.3.0 openmpi/3.0.0 b:Python/2.7.14
-boost/1.68.0         stable	gcc/7.3.0 openmpi/3.1.2 b:Python/2.7.14
-boost/1.68.0         stable	gcc/7.3.0 openmpi/3.1.3 b:Python/2.7.14
-boost/1.68.0-1       stable	gcc/7.3.0 openmpi/3.1.3 b:zlib/1.2.11
+boost/1.68.0	deprecated	gcc/7.3.0 openmpi/{1.10.7,2.1.5,3.0.0,3.1.2,3.1.3} b:Python/2.7.14
+boost/1.68.0	deprecated	gcc/8.2.0 openmpi/{1.10.7,2.1.5,3.1.2,3.1.3} b:Python/2.7.14
 
-boost/1.68.0         stable	gcc/8.2.0 openmpi/1.10.7 b:Python/2.7.14
-boost/1.68.0         stable	gcc/8.2.0 openmpi/2.1.5 b:Python/2.7.14
-boost/1.68.0         stable	gcc/8.2.0 openmpi/3.1.2 b:Python/2.7.14
-boost/1.68.0         stable	gcc/8.2.0 openmpi/3.1.3 b:Python/2.7.14
+boost/1.68.0-1	deprecated	gcc/7.3.0 openmpi/3.1.3 b:zlib/1.2.11
+boost/1.68.0-1	deprecated	gcc/7.3.0 mpich/3.3 b:zlib/1.2.11
 
-boost/1.68.0-1       stable	gcc/7.3.0 mpich/3.3 b:zlib/1.2.11
+boost/1.70.0	deprecated	gcc/7.3.0 openmpi/3.1.3 b:zlib/1.2.11
+boost/1.70.0	deprecated	gcc/7.4.0 openmpi/3.1.4 b:zlib/1.2.11
 
-boost/1.70.0         stable	gcc/7.3.0 openmpi/3.1.3 b:zlib/1.2.11
-boost/1.70.0         stable	gcc/7.4.0 openmpi/3.1.4 b:zlib/1.2.11
-
-boost/1.70.0         stable	gcc/{7.5.0,8.4.0,9.3.0,10.1.0} openmpi/3.1.6 b:zlib/1.2.11
-boost/1.73.0         stable	gcc/{7.5.0,8.4.0,9.3.0,10.1.0} openmpi/3.1.6 b:zlib/1.2.11
+boost/1.70.0	stable		gcc/{7.5.0,8.4.0,9.3.0,10.1.0} openmpi/3.1.6 b:zlib/1.2.11
+boost/1.73.0	stable		gcc/{7.5.0,8.4.0,9.3.0,10.1.0} openmpi/3.1.6 b:zlib/1.2.11


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "boost: deprecate variants build...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/178) |
> | **GitLab MR Number** | [178](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/178) |
> | **Date Originally Opened** | Tue, 2 Mar 2021 |
> | **Date Originally Merged** | Tue, 2 Mar 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #132