### PR TITLE
Resolve "amrex: deprecate all variants build with openmpi <= 3.1.5"

### DIFF
--- a/MPI/amrex/files/variants.rhel6
+++ b/MPI/amrex/files/variants.rhel6
@@ -1,14 +1,17 @@
-amrex/18.07_2d	stable		gcc/7.3.0 openmpi/{1.10.7,2.1.5,3.0.0,3.1.2,3.1.3} b:cmake/3.9.6
+amrex/18.07_2d	deprecated	gcc/7.3.0 openmpi/{1.10.7,2.1.5,3.0.0,3.1.2,3.1.3} b:cmake/3.9.6
 
-amrex/18.07_2d	stable		gcc/7.4.0 openmpi/3.1.4 b:cmake/3.10.3
+amrex/18.07_2d	deprecated	gcc/7.4.0 openmpi/3.1.4 b:cmake/3.10.3
 
-amrex/18.07_2d	stable		gcc/8.2.0 openmpi/{1.10.7,2.1.5,3.1.3} b:cmake/3.9.6
+amrex/18.07_2d	deprecated	gcc/8.2.0 openmpi/{1.10.7,2.1.5,3.1.3} b:cmake/3.9.6
 
-amrex/18.07_2d	stable		gcc/{7.3.0,8.2.0} mpich/3.2.1 b:cmake/3.9.6
+amrex/18.07_2d	deprecated	gcc/{7.3.0,8.2.0} mpich/3.2.1 b:cmake/3.9.6
 
-amrex/18.07_3d	stable		gcc/7.3.0 openmpi/{1.10.7,2.1.5,3.0.0,3.1.2,3.1.3} b:cmake/3.9.6
-amrex/18.07_3d	stable		gcc/7.4.0 openmpi/3.1.4 b:cmake/3.10.3
-amrex/18.07_3d	stable		gcc/8.2.0 openmpi/{1.10.7,2.1.5,3.1.3} b:cmake/3.9.6
+amrex/18.07_3d	deprecated	gcc/7.3.0 openmpi/{1.10.7,2.1.5,3.0.0,3.1.2,3.1.3} b:cmake/3.9.6
+amrex/18.07_3d	deprecated	gcc/7.4.0 openmpi/3.1.4 b:cmake/3.10.3
+amrex/18.07_3d	deprecated	gcc/8.2.0 openmpi/{1.10.7,2.1.5,3.1.3} b:cmake/3.9.6
+
+
+
 amrex/18.07_3d	stable		gcc/{7.3.0,8.2.0} mpich/3.2.1 b:cmake/3.9.6
 
 amrex/18.07_3d	stable		gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6 b:cmake/3.15.5


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "amrex: deprecate all variants b...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/180) |
> | **GitLab MR Number** | [180](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/180) |
> | **Date Originally Opened** | Tue, 2 Mar 2021 |
> | **Date Originally Merged** | Tue, 2 Mar 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #134