### PR TITLE
Resolve "H5hut: deprecate all variants build with openmpi <= 3.1.5"

### DIFF
--- a/HDF5/H5hut/files/variants.rhel6
+++ b/HDF5/H5hut/files/variants.rhel6
@@ -1,25 +1,22 @@
 H5hut/1.99.13	deprecated      gcc/{4.7.4,4.8.3,4.8.4,4.9.2} openmpi/{1.6.5,1.8.2,1.8.4} hdf5/{1.8.12,1.8.14}
 
+H5hut/1.99.13	deprecated	intel/15.3 openmpi/1.8.4 hdf5/{1.8.12,1.8.14}
+
 H5hut/2.0.0rc2	deprecated	gcc/4.8.5 openmpi/1.10.2 hdf5/1.8.17 b:automake/1.14 b:autoconf/2.69 b:libtool/2.4.2 b:Python/2.7.12 b:parmetis/4.0.3
 
 H5hut/2.0.0rc3	deprecated	gcc/5.4.0 openmpi/1.10.4 hdf5/1.8.17 b:automake/1.14 b:autoconf/2.69 b:libtool/2.4.2 b:Python/2.7.12 b:parmetis/4.0.3
 
-H5hut/2.0.0rc3	deprecated	gcc/4.8.5 openmpi/1.10.4 hdf5/1.8.18 b:automake/1.14 b:autoconf/2.69 b:libtool/2.4.2 b:Python/2.7.12 b:parmetis/4.0.3
-H5hut/2.0.0rc3	deprecated	gcc/4.9.4 openmpi/1.10.4 hdf5/1.8.18 b:automake/1.14 b:autoconf/2.69 b:libtool/2.4.2 b:Python/2.7.12 b:parmetis/4.0.3
-H5hut/2.0.0rc3	deprecated	gcc/5.4.0 openmpi/1.10.4 hdf5/1.8.18 b:automake/1.14 b:autoconf/2.69 b:libtool/2.4.2 b:Python/2.7.12 b:parmetis/4.0.3
-H5hut/2.0.0rc3	deprecated	gcc/6.2.0 openmpi/1.10.4 hdf5/1.8.18 b:automake/1.14 b:autoconf/2.69 b:libtool/2.4.2 b:Python/2.7.12 b:parmetis/4.0.3
+H5hut/2.0.0rc3	deprecated	gcc/{4.8.5,4.9.4,5.4.0,6.2.0} openmpi/1.10.4 hdf5/1.8.18 b:automake/1.14 b:autoconf/2.69 b:libtool/2.4.2 b:Python/2.7.12 b:parmetis/4.0.3
 
-H5hut/2.0.0rc4	deprecated	gcc/7.3.0 openmpi/1.10.7 hdf5/1.10.1 b:automake/1.15 b:autoconf/2.69 b:libtool/2.4.6 b:Python/2.7.12 b:parmetis/4.0.3
-H5hut/2.0.0rc4	deprecated	gcc/7.3.0 openmpi/2.1.2  hdf5/1.10.1 b:automake/1.15 b:autoconf/2.69 b:libtool/2.4.6 b:Python/2.7.12 b:parmetis/4.0.3
-H5hut/2.0.0rc4	deprecated	gcc/7.3.0 openmpi/3.0.0  hdf5/1.10.1 b:automake/1.15 b:autoconf/2.69 b:libtool/2.4.6 b:Python/2.7.12 b:parmetis/4.0.3
+H5hut/2.0.0rc4	deprecated	gcc/7.3.0 openmpi/{1.10.7,2.1.2,3.0.0} hdf5/1.10.1 b:automake/1.15 b:autoconf/2.69 b:libtool/2.4.6 b:Python/2.7.12 b:parmetis/4.0.3
+
 H5hut/2.0.0rc4	deprecated	gcc/7.3.0 openmpi/3.1.2  hdf5/1.10.3 b:automake/1.15 b:autoconf/2.69 b:libtool/2.4.6 b:Python/2.7.12 b:parmetis/4.0.3
-H5hut/2.0.0rc4	deprecated	intel/17.4 openmpi/1.10.7 hdf5/1.10.1 b:automake/1.15 b:autoconf/2.69 b:libtool/2.4.6 b:Python/2.7.12 b:parmetis/4.0.3
-H5hut/2.0.0rc4	deprecated	intel/17.4 openmpi/2.1.2  hdf5/1.10.1 b:automake/1.15 b:autoconf/2.69 b:libtool/2.4.6 b:Python/2.7.12 b:parmetis/4.0.3
-H5hut/2.0.0rc4	deprecated	intel/17.4 openmpi/3.0.0  hdf5/1.10.1 b:automake/1.15 b:autoconf/2.69 b:libtool/2.4.6 b:Python/2.7.12 b:parmetis/4.0.3
 
-H5hut/2.0.0rc5	stable		gcc/7.3.0 openmpi/3.1.3  hdf5/1.10.4 b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3
+H5hut/2.0.0rc4	deprecated	intel/17.4 openmpi/{1.10.7,2.1.2,3.0.0} hdf5/1.10.1 b:automake/1.15 b:autoconf/2.69 b:libtool/2.4.6 b:Python/2.7.12 b:parmetis/4.0.3
 
-H5hut/2.0.0rc6	stable		gcc/7.3.0 openmpi/3.1.3  hdf5/1.10.4 b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3
-H5hut/2.0.0rc6	stable		gcc/7.4.0 openmpi/3.1.4  hdf5/1.10.5 b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3
+H5hut/2.0.0rc5	deprecated	gcc/7.3.0 openmpi/3.1.3  hdf5/1.10.4 b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3
+
+H5hut/2.0.0rc6	deprecated	gcc/7.3.0 openmpi/3.1.3  hdf5/1.10.4 b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3
+H5hut/2.0.0rc6	deprecated	gcc/7.4.0 openmpi/3.1.4  hdf5/1.10.5 b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3
 H5hut/2.0.0rc6	stable		gcc/{7.5.0,8.4.0,9.3.0,10.1.0} openmpi/3.1.6  hdf5/1.10.6 b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "H5hut: deprecate all variants b...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/181) |
> | **GitLab MR Number** | [181](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/181) |
> | **Date Originally Opened** | Tue, 2 Mar 2021 |
> | **Date Originally Merged** | Wed, 3 Mar 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #135