### PR TITLE
Resolve "OPAL: deprecate all version < 2.0.0"

### DIFF
--- a/MPI/OPAL/files/variants.rhel6
+++ b/MPI/OPAL/files/variants.rhel6
@@ -1,25 +1,25 @@
-OPAL/1.3.0		deprecated	gcc/4.8.3 openmpi/1.8.2
-OPAL/1.3.1		deprecated	gcc/4.8.3 openmpi/1.8.2
-OPAL/1.3.2		stable		gcc/4.8.3 openmpi/1.8.2
-OPAL/1.4.0		stable		gcc/4.8.3 openmpi/1.8.2
-OPAL/1.4.0rc2		deprecated	gcc/4.8.3 openmpi/1.8.2
-OPAL/1.4.0rc3		deprecated	gcc/4.8.3 openmpi/1.8.2
-OPAL/1.5.0-20161209	deprecated	gcc/5.4.0 openmpi/1.10.4
-OPAL/1.5.0-20170126	deprecated	gcc/5.4.0 openmpi/1.10.4
-OPAL/1.5.1-20170216	deprecated	gcc/5.4.0 openmpi/1.10.4
-OPAL/1.5.1-20170217	deprecated	gcc/5.4.0 openmpi/1.10.4 dks/1.0.1 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 b:cmake/3.6.3 b:OpenBLAS/0.2.19
-OPAL/1.5.2		stable		gcc/5.4.0 openmpi/1.10.4 dks/1.0.2 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 b:cmake/3.6.3 b:OpenBLAS/0.2.19
+OPAL/1.3.0		removed		gcc/4.8.3 openmpi/1.8.2
+OPAL/1.3.1		removed		gcc/4.8.3 openmpi/1.8.2
+OPAL/1.3.2		removed		gcc/4.8.3 openmpi/1.8.2
+OPAL/1.4.0		removed		gcc/4.8.3 openmpi/1.8.2
+OPAL/1.4.0rc2		removed		gcc/4.8.3 openmpi/1.8.2
+OPAL/1.4.0rc3		removed		gcc/4.8.3 openmpi/1.8.2
+OPAL/1.5.0-20161209	removed		gcc/5.4.0 openmpi/1.10.4
+OPAL/1.5.0-20170126	removed		gcc/5.4.0 openmpi/1.10.4
+OPAL/1.5.1-20170216	removed		gcc/5.4.0 openmpi/1.10.4
+OPAL/1.5.1-20170217	removed		gcc/5.4.0 openmpi/1.10.4 dks/1.0.1 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 b:cmake/3.6.3 b:OpenBLAS/0.2.19
+OPAL/1.5.2		removed		gcc/5.4.0 openmpi/1.10.4 dks/1.0.2 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 b:cmake/3.6.3 b:OpenBLAS/0.2.19
 
-OPAL/1.6.0rc1		deprecated	gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.1 b:cmake/3.6.3 b:OpenBLAS/0.2.19
-OPAL/1.6.0rc2		deprecated	gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.1 b:cmake/3.6.3 b:OpenBLAS/0.2.19
-OPAL/1.6.0rc3		deprecated	gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
-OPAL/1.6.0rc4		deprecated	gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
-OPAL/1.6.0rc5		deprecated	gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
-OPAL/1.6.0rc6		deprecated	gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
-OPAL/1.6.0		stable		gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
-OPAL/1.6.1		stable		gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
-OPAL/1.6.2		stable		gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
-OPAL/2.0.0rc2		deprecated	gcc/7.3.0 openmpi/3.0.0 boost/1.66.0 hdf5/1.10.1 H5hut/2.0.0rc4 gsl/2.4 trilinos/12.12.1 b:cmake/3.9.6 b:OpenBLAS/0.2.20
-OPAL/2.0.2		stable		gcc/7.3.0 openmpi/3.1.3 boost/1.68.0 hdf5/1.10.4 H5hut/2.0.0rc5 gsl/2.5 trilinos/12.12.1 b:cmake/3.9.6 b:OpenBLAS/0.2.20
+OPAL/1.6.0rc1		removed		gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.1 b:cmake/3.6.3 b:OpenBLAS/0.2.19
+OPAL/1.6.0rc2		removed		gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.1 b:cmake/3.6.3 b:OpenBLAS/0.2.19
+OPAL/1.6.0rc3		removed		gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
+OPAL/1.6.0rc4		removed		gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
+OPAL/1.6.0rc5		removed		gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
+OPAL/1.6.0rc6		removed		gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
+OPAL/1.6.0		deprecated	gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
+OPAL/1.6.1		deprecated	gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
+OPAL/1.6.2		deprecated	gcc/5.4.0 openmpi/1.10.4 boost/1.62.0 hdf5/1.8.18 H5hut/2.0.0rc3 gsl/2.2.1 trilinos/12.10.1 cuda/8.0.44 dks/1.1.2 b:cmake/3.6.3 b:OpenBLAS/0.2.19
+OPAL/2.0.0rc2		removed		gcc/7.3.0 openmpi/3.0.0 boost/1.66.0 hdf5/1.10.1 H5hut/2.0.0rc4 gsl/2.4 trilinos/12.12.1 b:cmake/3.9.6 b:OpenBLAS/0.2.20
+OPAL/2.0.2		deprecated	gcc/7.3.0 openmpi/3.1.3 boost/1.68.0 hdf5/1.10.4 H5hut/2.0.0rc5 gsl/2.5 trilinos/12.12.1 b:cmake/3.9.6 b:OpenBLAS/0.2.20
 
 OPAL/2.4.0		stable		gcc/8.4.0 openmpi/3.1.6 boost/1.73.0 hdf5/1.10.6 H5hut/2.0.0rc6 gsl/2.6 trilinos/12.18.1 amrex/18.07_3d b:cmake/3.15.5


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "OPAL: deprecate all version < 2...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/182) |
> | **GitLab MR Number** | [182](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/182) |
> | **Date Originally Opened** | Wed, 3 Mar 2021 |
> | **Date Originally Merged** | Wed, 3 Mar 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #136