### PR TITLE
Resolve "SUperLU_DIST: deprecate all variants build with openmpi <= 3.1.5"

### DIFF
--- a/MPI/SuperLU_DIST/build
+++ b/MPI/SuperLU_DIST/build
@@ -2,6 +2,7 @@
 
 # :FIXME: need review!
 
+pbuild::add_to_group MPI
 pbuild::configure() {
 	case ${COMPILER} in
 	gcc )
@@ -50,10 +51,3 @@ pbuild::install() {
 	install -m 0444 "${SRC_DIR}"/SRC/*.h "${PREFIX}/include"
 }
 
-
-pbuild::add_to_group 'MPI'
-pbuild::set_runtime_dependencies "${COMPILER}" "${MPI} 'OpenBLAS' 'parmetis'"
-pbuild::set_build_dependencies "${COMPILER}" "${MPI}" 'OpenBLAS' 'parmetis'
-pbuild::install_docfiles 'README'
-pbuild::make_all
-pbuild::cleanup_src

--- a/MPI/SuperLU_DIST/files/variants.rhel6
+++ b/MPI/SuperLU_DIST/files/variants.rhel6
@@ -1,0 +1,1 @@
+SuperLU_DIST/3.3	deprecated	gcc/{4.7.4,4.8.3,4.8.4,4.9.2} openmpi/{1.6.5,1.8.2,1.8.4}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "SUperLU_DIST: deprecate all var...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/183) |
> | **GitLab MR Number** | [183](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/183) |
> | **Date Originally Opened** | Wed, 3 Mar 2021 |
> | **Date Originally Merged** | Wed, 3 Mar 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #137