### PR TITLE
Resolve "SuperLU_DIST: deprecate variants build with old Intel compiler"

### DIFF
--- a/MPI/SuperLU_DIST/files/variants.rhel6
+++ b/MPI/SuperLU_DIST/files/variants.rhel6
@@ -1,1 +1,2 @@
 SuperLU_DIST/3.3	deprecated	gcc/{4.7.4,4.8.3,4.8.4,4.9.2} openmpi/{1.6.5,1.8.2,1.8.4}
+SuperLU_DIST/3.3	deprecated	intel/15.3 openmpi/1.8.4


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "SuperLU_DIST: deprecate variant...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/184) |
> | **GitLab MR Number** | [184](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/184) |
> | **Date Originally Opened** | Wed, 3 Mar 2021 |
> | **Date Originally Merged** | Wed, 3 Mar 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #138