### PR TITLE
Added openmpi/4.0.5_slurm with cuda/11.0.3

### DIFF
--- a/Compiler/openmpi/files/variants.merlin6
+++ b/Compiler/openmpi/files/variants.merlin6
@@ -20,6 +20,8 @@ openmpi/4.0.4_slurm     stable     intel/{15.2,17.4,18.4,20.1}
 
 openmpi/3.1.6_slurm     stable     intel/20.4 cuda/11.1.0
 
+
+openmpi/4.0.5_slurm     stable     gcc/9.2.0 cuda/11.0.3
 openmpi/4.0.5_slurm     stable     gcc/{8.4.0,9.3.0} cuda/11.1.0
 openmpi/4.0.5_slurm     stable     intel/20.4 cuda/11.1.0
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | caubet_m |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Added openmpi/4.0.5_slurm with cuda/11.0...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/187) |
> | **GitLab MR Number** | [187](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/187) |
> | **Date Originally Opened** | Fri, 5 Mar 2021 |
> | **Date Originally Merged** | Fri, 5 Mar 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_