### PR TITLE
Relion 3.1.2 and 3.1.1-1

### DIFF
--- a/EM/relion/README.md
+++ b/EM/relion/README.md
@@ -9,3 +9,5 @@ admin account.
 Currently only gcc/7.4.0 is used. Better performance is reported with intel icc
 and MKL, but this would require additional openmpi variants.
 
+After running ./build, install relion scripts from the repository at
+https://git.psi.ch/lsm-hpce/relion-scripts

--- a/EM/relion/files/variants
+++ b/EM/relion/files/variants
@@ -6,4 +6,6 @@ relion/3.0.8-1	stable	gcc/9.3.0 openmpi/4.0.5_slurm cuda/11.0.3 b:cmake/3.15.5 b
 relion/3.1-beta	deprecated	gcc/7.4.0 openmpi/3.1.4_merlin6 cuda/9.2.148 b:cmake/3.14.0 b:tiff/4.0.9
 relion/3.1.0	deprecated	gcc/7.5.0 openmpi/4.0.4_slurm cuda/10.0.130 b:cmake/3.15.5 b:tiff/4.0.9 b:git/2.22.0
 relion/3.1.0-1	stable	gcc/7.5.0 openmpi/4.0.4_slurm cuda/10.1.105 b:cmake/3.15.5 b:tiff/4.0.9 b:git/2.22.0
-relion/3.1.1	stable	gcc/9.3.0 openmpi/4.0.4_slurm cuda/11.0.3 b:cmake/3.15.5 b:tiff/4.0.9 b:git/2.22.0
+relion/3.1.1	deprecated	gcc/9.3.0 openmpi/4.0.4_slurm cuda/11.0.3 b:cmake/3.15.5 b:tiff/4.0.9 b:git/2.22.0
+relion/3.1.1-1	stable	gcc/9.2.0 openmpi/4.0.5_slurm cuda/11.0.3 b:cmake/3.15.5 b:tiff/4.0.9 b:git/2.22.0
+relion/3.1.2	stable	gcc/9.2.0 openmpi/4.0.5_slurm cuda/11.0.3 b:cmake/3.15.5 b:tiff/4.0.9 b:git/2.22.0


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | bliven_s |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Relion 3.1.2 and 3.1.1-1](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/188) |
> | **GitLab MR Number** | [188](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/188) |
> | **Date Originally Opened** | Fri, 5 Mar 2021 |
> | **Date Originally Merged** | Fri, 5 Mar 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

3.1.1-1 is compiled against cuda-aware openmpi/4.0.5_slurm (CUDA
11.0.3), which fixes some bugs.