### PR TITLE
Resolve "boost: new variants for current GCC's"

### DIFF
--- a/MPI/boost/files/variants.merlin6
+++ b/MPI/boost/files/variants.merlin6
@@ -1,4 +1,5 @@
 boost/1.70.0_slurm         stable	gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6_slurm b:zlib/1.2.11
 boost/1.73.0_slurm         stable	gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6_slurm b:zlib/1.2.11
 boost/1.73.0_slurm         unstable	gcc/{7.5.0,8.4.0,9.3.0} openmpi/4.0.5_slurm b:zlib/1.2.11
+boost/1.73.0-1_slurm       unstable	gcc/{8.4.0,9.3.0,10.2.0} openmpi/4.0.5-1_slurm b:zlib/1.2.11
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "boost: new variants for current...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/213) |
> | **GitLab MR Number** | [213](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/213) |
> | **Date Originally Opened** | Mon, 26 Apr 2021 |
> | **Date Originally Merged** | Mon, 26 Apr 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #151