### PR TITLE
Fix dependency problem in relion/3.0.8-1

### DIFF
--- a/EM/relion/files/variants
+++ b/EM/relion/files/variants
@@ -2,7 +2,7 @@ relion/2.1.b1	deprecated	gcc/4.9.4 openmpi/2.0.1 cuda/8.0.44
 relion/2.1	stable	gcc/9.3.0 openmpi/4.0.4_slurm cuda/11.0.3 b:cmake/3.15.5 b:tiff/4.0.9 b:git/2.22.0
 relion/3.0_beta	deprecated	gcc/4.9.4 openmpi/2.0.1 cuda/8.0.44
 relion/3.0.8	deprecated	gcc/7.4.0 openmpi/3.1.4_merlin6 cuda/9.2.148 b:cmake/3.14.0 b:tiff/4.0.9
-relion/3.0.8-1	stable	gcc/9.3.0 openmpi/4.0.5_slurm cuda/11.0.3 b:cmake/3.15.5 b:tiff/4.0.9 b:git/2.22.0
+relion/3.0.8-1	stable	gcc/9.2.0 openmpi/4.0.5_slurm cuda/11.0.3 b:cmake/3.15.5 b:tiff/4.0.9 b:git/2.22.0
 relion/3.1-beta	deprecated	gcc/7.4.0 openmpi/3.1.4_merlin6 cuda/9.2.148 b:cmake/3.14.0 b:tiff/4.0.9
 relion/3.1.0	deprecated	gcc/7.5.0 openmpi/4.0.4_slurm cuda/10.0.130 b:cmake/3.15.5 b:tiff/4.0.9 b:git/2.22.0
 relion/3.1.0-1	stable	gcc/7.5.0 openmpi/4.0.4_slurm cuda/10.1.105 b:cmake/3.15.5 b:tiff/4.0.9 b:git/2.22.0


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | bliven_s |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Fix dependency problem in relion/3.0.8-1](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/224) |
> | **GitLab MR Number** | [224](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/224) |
> | **Date Originally Opened** | Mon, 26 Jul 2021 |
> | **Date Originally Merged** | Mon, 26 Jul 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Somehow the dependency in the variants file was wrong, causing a load failure.