### PR TITLE
Added openmpi/4.0.5-2_slurm and UCX 1.11

### DIFF
--- a/Compiler/openmpi/files/variants.merlin6
+++ b/Compiler/openmpi/files/variants.merlin6
@@ -26,6 +26,7 @@ openmpi/4.0.5_slurm     stable     gcc/{8.4.0,9.3.0} cuda/11.1.0
 openmpi/4.0.5_slurm     stable     intel/20.4 cuda/11.1.0
 
 openmpi/4.0.5-1_slurm   unstable   gcc/{8.4.0,9.3.0,10.2.0} cuda/11.2.2 b:ucx/1.10.0-1_slurm
+openmpi/4.0.5-2_slurm   unstable   gcc/10.2.0 cuda/11.3.0 b:ucx/1.11.0_slurm
 
 openmpi/4.0.5-1_dgx     unstable   gcc/{8.4.0,9.3.0,10.2.0} cuda/11.2.2 b:ucx/1.10.0-1_dgx
 openmpi/4.1.0-1_dgx     unstable   gcc/10.2.0 cuda/11.2.2 b:ucx/1.10.0-1_dgx

--- a/Libraries/ucx/files/variants.merlin6
+++ b/Libraries/ucx/files/variants.merlin6
@@ -1,4 +1,5 @@
 ucx/1.9.0_slurm           unstable     cuda/11.1.0 b:doxygen/1.8.14 b:knem/1.1.4
 ucx/1.10.0_slurm          unstable     cuda/11.3.0 b:doxygen/1.8.14 b:knem/1.1.4 b:GDRCopy/2.2.0
+ucx/1.11.0_slurm          unstable     cuda/11.3.0 b:doxygen/1.8.14 b:knem/1.1.4 b:GDRCopy/2.2.0
 ucx/1.10.0-1_dgx          unstable     cuda/11.2.2 b:doxygen/1.8.14 b:knem/1.1.4 b:GDRCopy/2.2.0
 ucx/1.10.0-1_slurm        unstable     cuda/11.2.2 b:doxygen/1.8.14 b:knem/1.1.4 b:GDRCopy/2.2.0


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | caubet_m |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Added openmpi/4.0.5-2_slurm and UCX 1.11](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/226) |
> | **GitLab MR Number** | [226](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/226) |
> | **Date Originally Opened** | Fri, 13 Aug 2021 |
> | **Date Originally Merged** | Fri, 13 Aug 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_