### PR TITLE
openmpi/4.0.4_slurm to deprecated

### DIFF
--- a/Compiler/openmpi/files/variants.merlin6
+++ b/Compiler/openmpi/files/variants.merlin6
@@ -12,7 +12,7 @@ openmpi/2.1.6_slurm     deprecated intel/{15.2,17.4,18.4}
 openmpi/3.0.5_slurm     deprecated  gcc/{4.9.4,5.5.0,6.5.0,7.4.0,8.3.0,9.2.0}
 openmpi/3.0.5_slurm     deprecated  intel/{15.2,17.4,18.4}
 
-openmpi/3.1.6_slurm     deprecated  gcc/{4.9.4,5.5.0,6.5.0,7.5.0,8.4.0,9.3.0}
+openmpi/3.1.6_slurm     deprecated  gcc/{4.9.4,5.5.0,6.5.0}
 openmpi/3.1.6_slurm     stable      gcc/{7.5.0,8.4.0,9.3.0}
 openmpi/3.1.6_slurm     deprecated  intel/{15.2,17.4,18.4,20.1}
 openmpi/3.1.6_slurm     deprecated  intel/20.4 cuda/11.1.0
@@ -20,9 +20,9 @@ openmpi/3.1.6_slurm     deprecated  intel/20.4 cuda/11.1.0
 openmpi/4.0.3_slurm     deprecated  gcc/{4.9.4,5.5.0,6.5.0,7.5.0,8.4.0,9.3.0}
 openmpi/4.0.3_slurm     deprecated  intel/{15.2,17.4,18.4,20.1}
 
-openmpi/4.0.4_slurm     stable      gcc/{4.9.4,5.5.0,6.5.0,7.5.0,8.4.0,9.3.0}
+openmpi/4.0.4_slurm     deprecated  gcc/{4.9.4,5.5.0,6.5.0,7.5.0,8.4.0,9.3.0}
 openmpi/4.0.4_slurm     deprecated  intel/{15.2,17.4}
-openmpi/4.0.4_slurm     stable      intel/{18.4,20.1}
+openmpi/4.0.4_slurm     deprecated  intel/{18.4,20.1}
 
 openmpi/4.0.5_slurm     stable     gcc/9.2.0 cuda/11.0.3
 openmpi/4.0.5_slurm     stable     gcc/{8.4.0,9.3.0} cuda/11.1.0


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | caubet_m |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [openmpi/4.0.4_slurm to deprecated](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/232) |
> | **GitLab MR Number** | [232](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/232) |
> | **Date Originally Opened** | Wed, 17 Nov 2021 |
> | **Date Originally Merged** | Wed, 17 Nov 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_