### PR TITLE
Resolve "openmpi: deprecate old versions"

### DIFF
--- a/Compiler/openmpi/files/variants.rhel6
+++ b/Compiler/openmpi/files/variants.rhel6
@@ -38,7 +38,7 @@ openmpi/3.1.1	deprecated	gcc/{8.1.0,8.2.0}
 openmpi/3.1.2	deprecated	gcc/{7.3.0,8.2.0}
 openmpi/3.1.2	deprecated	intel/18.4
 openmpi/3.1.3	deprecated	gcc/{4.8.5,5.5.0,6.4.0,6.5.0,7.3.0,8.2.0,8.3.0}
-openmpi/3.1.4   stable          gcc/{7.4.0,8.3.0,9.1.0,9.2.0}
+openmpi/3.1.4   deprecated	gcc/{7.4.0,8.3.0,9.1.0,9.2.0}
 
 openmpi/3.1.6	stable		gcc/{7.5.0,8.4.0,9.3.0,10.1.0}
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "openmpi: deprecate old versions...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/235) |
> | **GitLab MR Number** | [235](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/235) |
> | **Date Originally Opened** | Wed, 17 Nov 2021 |
> | **Date Originally Merged** | Thu, 18 Nov 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #164