### PR TITLE
Resolve "fftw: deprecate all modules build with openmpi 3"

### DIFF
--- a/MPI/fftw/files/variants
+++ b/MPI/fftw/files/variants
@@ -1,9 +1,9 @@
 fftw/3.3.8		deprecated	gcc/{7.3.0,8.2.0} mpich/3.2.1 openmpi/3.1.3
 # Use older MPI version on merlin5
-fftw/3.3.8-1_sp_merlin	unstable	gcc/8.2.0 mpich/3.2.1 openmpi/3.1.1
-fftw/3.3.8-1_dp_merlin	unstable	gcc/8.2.0 mpich/3.2.1 openmpi/3.1.1
+fftw/3.3.8-1_sp_merlin	deprecated	gcc/8.2.0 mpich/3.2.1 openmpi/3.1.1
+fftw/3.3.8-1_dp_merlin	deprecated	gcc/8.2.0 mpich/3.2.1 openmpi/3.1.1
 # Merlin6 mpi version
-fftw/3.3.8-1_sp_merlin6	unstable	gcc/{7.4.0,8.3.0} mpich/3.3 openmpi/3.1.4_merlin6
-fftw/3.3.8-1_dp_merlin6	unstable	gcc/{7.4.0,8.3.0} mpich/3.3 openmpi/3.1.4_merlin6
+fftw/3.3.8-1_sp_merlin6	deprecated	gcc/{7.4.0,8.3.0} mpich/3.3 openmpi/3.1.4_merlin6
+fftw/3.3.8-1_dp_merlin6	deprecated	gcc/{7.4.0,8.3.0} mpich/3.3 openmpi/3.1.4_merlin6
 
 fftw/3.3.9_merlin6	unstable	gcc/{8.4.0,9.3.0,10.2.0} openmpi/4.0.5-1_slurm


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "fftw: deprecate all modules bui...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/240) |
> | **GitLab MR Number** | [240](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/240) |
> | **Date Originally Opened** | Wed, 17 Nov 2021 |
> | **Date Originally Merged** | Wed, 17 Nov 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #169