### PR TITLE
Resolve "lammps: deprecate all modules build with openmpi 3 and older"

### DIFF
--- a/MPI/lammps/2017/variants
+++ b/MPI/lammps/2017/variants
@@ -1,1 +1,1 @@
-lammps/2017.8	unstable	gcc/5.4.0 openmpi/1.10.4
+lammps/2017.8	deprecated	gcc/5.4.0 openmpi/1.10.4

--- a/MPI/lammps/2018/variants
+++ b/MPI/lammps/2018/variants
@@ -1,3 +1,3 @@
-lammps/2018.3          unstable  gcc/7.3.0 openmpi/3.0.1
-lammps/2018.3_merlin   unstable	 gcc/8.2.0 openmpi/3.1.1 b:cmake/3.9.6
-lammps/2018.11_merlin  stable    gcc/8.2.0 openmpi/3.1.1 Python/2.7.14 b:cmake/3.9.6
+lammps/2018.3_merlin	deprecated	gcc/8.2.0 openmpi/3.1.1 b:cmake/3.9.6
+lammps/2018.11_merlin	deprecated	gcc/8.2.0 openmpi/3.1.1 Python/2.7.14 b:cmake/3.9.6
+lammps/2018.11_merlin2	deprecated	gcc/8.2.0 openmpi/3.1.1 Python/2.7.14 b:cmake/3.9.6

--- a/MPI/lammps/2019/variants
+++ b/MPI/lammps/2019/variants
@@ -1,1 +1,1 @@
-lammps/2019.8_merlin6  stable    gcc/8.3.0 openmpi/3.1.4_merlin6
+lammps/2019.8_merlin6  deprecated    gcc/8.3.0 openmpi/3.1.4_merlin6


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "lammps: deprecate all modules b...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/241) |
> | **GitLab MR Number** | [241](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/241) |
> | **Date Originally Opened** | Wed, 17 Nov 2021 |
> | **Date Originally Merged** | Wed, 17 Nov 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #170