### PR TITLE
Resolve "hdf5: deprecate modules build with openmpi 3 and older"

### DIFF
--- a/MPI/hdf5/files/variants.rhel6
+++ b/MPI/hdf5/files/variants.rhel6
@@ -34,7 +34,7 @@ hdf5/1.8.17	deprecated	 gcc/{5.3.0,6.1.0,6.2.0} openmpi/1.10.2
 hdf5/1.8.18	deprecated	gcc/{4.8.5,4.9.4,5.4.0,6.2.0} openmpi/1.10.4
 
 hdf5/1.8.20	deprecated	gcc/4.8.5 openmpi/1.10.4
-hdf5/1.8.20	deprecated	gcc/7.3.0 openmpi/{1.10.7,2.1.5}
+hdf5/1.8.20	deprecated	gcc/7.3.0 openmpi/{1.10.7,2.1.5,3.1.3}
 
 hdf5/1.10.0	deprecated	gcc/{4.8.5,5.3.0,6.1.0} openmpi/1.10.2
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "hdf5: deprecate modules build w...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/243) |
> | **GitLab MR Number** | [243](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/243) |
> | **Date Originally Opened** | Wed, 17 Nov 2021 |
> | **Date Originally Merged** | Wed, 17 Nov 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #172