### PR TITLE
Resolve "H5hut: new modules for 2.0.0rc6 with gcc/10.3.0 and openmpi/4.0.5"

### DIFF
--- a/HDF5/H5hut/files/variants.merlin6
+++ b/HDF5/H5hut/files/variants.merlin6
@@ -1,2 +1,3 @@
 H5hut/2.0.0rc6_slurm	stable	gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6_slurm  hdf5/1.10.6_slurm b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3_slurm
+H5hut/2.0.0rc6_slurm	stable	gcc/10.3.0 openmpi/4.0.5-1_slurm  hdf5/1.10.7_slurm b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3_slurm
 

--- a/HDF5/H5hut/files/variants.rhel6
+++ b/HDF5/H5hut/files/variants.rhel6
@@ -20,3 +20,5 @@ H5hut/2.0.0rc6	deprecated	gcc/7.3.0 openmpi/3.1.3  hdf5/1.10.4 b:automake/1.16.1
 H5hut/2.0.0rc6	deprecated	gcc/7.4.0 openmpi/3.1.4  hdf5/1.10.5 b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3
 H5hut/2.0.0rc6	stable		gcc/{7.5.0,8.4.0,9.3.0,10.1.0} openmpi/3.1.6  hdf5/1.10.6 b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3
 
+H5hut/2.0.0rc6	stable		gcc/10.3.0 openmpi/4.0.5  hdf5/1.10.7 b:automake/1.16.1 b:autoconf/2.69 b:libtool/2.4.6-1 b:Python/2.7.12 b:parmetis/4.0.3
+


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "H5hut: new modules for 2.0.0rc6...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/263) |
> | **GitLab MR Number** | [263](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/263) |
> | **Date Originally Opened** | Fri, 19 Nov 2021 |
> | **Date Originally Merged** | Fri, 19 Nov 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #192