### PR TITLE
UCX: moving releases to stable and deprecated

### DIFF
--- a/Libraries/ucx/files/variants.merlin6
+++ b/Libraries/ucx/files/variants.merlin6
@@ -1,5 +1,7 @@
-ucx/1.9.0_slurm           unstable   cuda/11.1.0 b:doxygen/1.8.14 b:knem/1.1.4
+ucx/1.9.0_slurm           stable     cuda/11.1.0 b:doxygen/1.8.14 b:knem/1.1.4
 ucx/1.10.0_slurm          stable     cuda/11.3.0 b:doxygen/1.8.14 b:knem/1.1.4 b:GDRCopy/2.2.0
-ucx/1.11.0_slurm          stable     cuda/11.3.0 b:doxygen/1.8.14 b:knem/1.1.4 b:GDRCopy/2.2.0
-ucx/1.10.0-1_dgx          unstable   cuda/11.2.2 b:doxygen/1.8.14 b:knem/1.1.4 b:GDRCopy/2.2.0
 ucx/1.10.0-1_slurm        stable     cuda/11.2.2 b:doxygen/1.8.14 b:knem/1.1.4 b:GDRCopy/2.2.0
+ucx/1.11.0_slurm          stable     cuda/11.3.0 b:doxygen/1.8.14 b:knem/1.1.4 b:GDRCopy/2.2.0
+
+ucx/1.9.0_dgx             deprecated cuda/11.1.0 b:doxygen/1.8.14 b:knem/1.1.4
+ucx/1.10.0-1_dgx          deprecated cuda/11.2.2 b:doxygen/1.8.14 b:knem/1.1.4 b:GDRCopy/2.2.0


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | caubet_m |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [UCX: moving releases to stable and depre...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/282) |
> | **GitLab MR Number** | [282](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/282) |
> | **Date Originally Opened** | Tue, 23 Nov 2021 |
> | **Date Originally Merged** | Tue, 23 Nov 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_