### PR TITLE
Add OpenMPI 4.1.1 (gcc-10.2.0,ucx-1.11.2,cuda-11.3.0)

### DIFF
--- a/Compiler/openmpi/files/variants.merlin6
+++ b/Compiler/openmpi/files/variants.merlin6
@@ -31,6 +31,8 @@ openmpi/4.0.5_slurm     stable     intel/20.4 cuda/11.1.0
 openmpi/4.0.5-1_slurm   stable     gcc/{8.4.0,9.3.0,10.2.0,10.3.0} cuda/11.2.2 b:ucx/1.10.0-1_slurm
 openmpi/4.0.5-2_slurm   unstable   gcc/10.2.0 cuda/11.3.0 b:ucx/1.11.0_slurm
 
+openmpi/4.1.1_slurm     unstable   gcc/10.2.0 cuda/11.3.0 b:ucx/1.11.2_slurm
+
 openmpi/4.0.5-1_dgx     deprecated gcc/{8.4.0,9.3.0,10.2.0} cuda/11.2.2 b:ucx/1.10.0-1_dgx
 openmpi/4.1.0-1_dgx     deprecated gcc/10.2.0 cuda/11.2.2 b:ucx/1.10.0-1_dgx
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | caubet_m |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Add OpenMPI 4.1.1 (gcc-10.2.0,ucx-1.11.2...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/288) |
> | **GitLab MR Number** | [288](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/288) |
> | **Date Originally Opened** | Wed, 8 Dec 2021 |
> | **Date Originally Merged** | Wed, 8 Dec 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_