### PR TITLE
Restore: Libraries UCX 1.11.2_slurm, which was deleted by mistake

### DIFF
--- a/Libraries/ucx/files/variants.merlin6
+++ b/Libraries/ucx/files/variants.merlin6
@@ -2,6 +2,7 @@ ucx/1.9.0_slurm           stable     cuda/11.1.0 b:doxygen/1.8.14 b:knem/1.1.4
 ucx/1.10.0_slurm          stable     cuda/11.3.0 b:doxygen/1.8.14 b:knem/1.1.4 b:GDRCopy/2.2.0
 ucx/1.10.0-1_slurm        stable     cuda/11.2.2 b:doxygen/1.8.14 b:knem/1.1.4 b:GDRCopy/2.2.0
 ucx/1.11.0_slurm          stable     cuda/11.3.0 b:doxygen/1.8.14 b:knem/1.1.4 b:GDRCopy/2.2.0
+ucx/1.11.2_slurm          unstable   cuda/11.3.0 b:doxygen/1.9.2  b:knem/1.1.4 b:GDRCopy/2.2.0
 ucx/1.11.2-1_slurm        unstable   cuda/11.4.3 b:doxygen/1.9.2  b:knem/1.1.4 b:GDRCopy/2.2.0
 ucx/1.11.2-2_slurm        unstable   cuda/11.5.1 b:doxygen/1.9.2  b:knem/1.1.4 b:GDRCopy/2.2.0
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | caubet_m |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Restore: Libraries UCX 1.11.2_slurm, whi...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/294) |
> | **GitLab MR Number** | [294](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/294) |
> | **Date Originally Opened** | Tue, 25 Jan 2022 |
> | **Date Originally Merged** | Tue, 25 Jan 2022 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_