### PR TITLE
Mark psi-python as conflicting with anaconda.

### DIFF
--- a/Programming/psi-python27/modulefile
+++ b/Programming/psi-python27/modulefile
@@ -15,4 +15,4 @@ The distribution is enriched by PSI specific packages.
 
 set dont-setenv { LD_LIBRARY_PATH }
 
-
+conflict  anaconda


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | bliven_s |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Mark psi-python as conflicting with anac...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/295) |
> | **GitLab MR Number** | [295](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/295) |
> | **Date Originally Opened** | Tue, 25 Jan 2022 |
> | **Date Originally Merged** | Wed, 16 Feb 2022 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

These changes have already been applied by hand.

See #155