### PR TITLE
Deprecating crYOLO/1.2.3 and moving other versions to stable

### DIFF
--- a/EM/crYOLO/files/variants
+++ b/EM/crYOLO/files/variants
@@ -1,5 +1,5 @@
-crYOLO/1.2.3	unstable	cuda/9.0.176
-crYOLO/1.5.6_gpu	unstable	anaconda/2019.07
-crYOLO/1.6.1_gpu	unstable	anaconda/2019.07
-crYOLO/1.6.1_cpu	unstable	anaconda/2019.07
+crYOLO/1.2.3	deprecated	cuda/9.0.176
+crYOLO/1.5.6_gpu	stable	anaconda/2019.07
+crYOLO/1.6.1_gpu	stable	anaconda/2019.07
+crYOLO/1.6.1_cpu	stable	anaconda/2019.07
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | bliven_s |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Deprecating crYOLO/1.2.3 and moving othe...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/299) |
> | **GitLab MR Number** | [299](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/299) |
> | **Date Originally Opened** | Wed, 16 Feb 2022 |
> | **Date Originally Merged** | Wed, 16 Feb 2022 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

1.2.3 was based on miniconda and should be removed in the future