### PR TITLE
Resolve "ioapi/3.2 with gcc/11.2.0 openmpi/4.1.3_slurm, hdf5/1.13.1_slurm"

### DIFF
--- a/HDF5/ioapi/build
+++ b/HDF5/ioapi/build
@@ -37,6 +37,7 @@ pbuild::pre_configure_Linux() {
 		;;
 	gcc )
 		BIN='Linux2_x86_64gfortmpi'
+		cp -av "${BUILDBLOCK_DIR}/files/Makeinclude.${BIN}" "ioapi"
 		;;
 	* )
 		std::die 4 "Compiler '${COMPILER}' is not supported on ${OS}!"
@@ -60,6 +61,8 @@ pbuild::configure() {
 
 pbuild::compile() {
 	make "${CONFIGURE_ARGS[@]}" all
+	make "${CONFIGURE_ARGS[@]}" m3tools
+	 
 }
 
 pbuild::install() {

--- a/HDF5/ioapi/files/Makeinclude.Linux2_x86_64gfortmpi
+++ b/HDF5/ioapi/files/Makeinclude.Linux2_x86_64gfortmpi
@@ -1,0 +1,46 @@
+# Version "$Id: Makeinclude.Linux2_x86_64gfortmpi 1 2017-06-10 18:05:20Z coats $"
+#
+#  Build MPI/PnetCDF distributed-file support using "mpif90" and "mpcc",
+#  where compilers are built "on top of" Gnu compilers
+#
+#  12/2013 by CJC: Conditional preprocessor-code "-DNEED_ARGS=1"
+#  to implement  IARGC() and GETARG() for compilers
+#  ("gfortran" version 4.8 or later to be exact) that insist on
+#  enforcing F2003-only with no backwards nor industry-standards compatibility.
+#
+#  Remove "-DNEED_ARGS=1" from ARCHFLAGS for version 4.7.x and earlier
+#
+# Use "-march=native -mtune=native" if compile-platform and compute-platform
+# are the same.
+# Use "-Wall -Wsurprising" for full diagnostics.
+
+AR   = ar
+CC   = mpicc
+CXX  = mpiCC
+FC   = mpif90
+M4   = m4
+LINK = $(CC)
+
+## Module-include-directory command
+MODI = -I
+E132 = -ffixed-line-length-132
+
+MFLAGS    = -ffast-math -funroll-loops -fallow-argument-mismatch -m64  #  -Wall -Wsurprising -march=native -mtune=native
+
+OMPFLAGS  = -fopenmp
+OMPLIBS   = -fopenmp
+COPTFLAGS = -O3 ${MFLAGS}
+FOPTFLAGS = -O3 ${MFLAGS}
+FPPFLAGS  = -DF90=1 -DIOAPI_PNCF=1
+FSFLAGS   = -fno-automatic -fallow-argument-mismatch
+ARCHFLAGS = \
+ -DAUTO_ARRAYS=1 \
+ -DF90=1 -DFLDMN=1 \
+ -DFSTR_L=int \
+ -DIOAPI_NO_STDOUT=1 \
+ -DNEED_ARGS=1
+PARFLAGS  =
+ARCHLIB   = -dynamic -lstdc++ -lm -lpthread -lc
+
+M4DEFFILE = $(PVM_ROOT)/conf/$(PVM_ARCH).m4
+PVMLIBS   = -lpvm3

--- a/HDF5/ioapi/files/variants.slurm
+++ b/HDF5/ioapi/files/variants.slurm
@@ -1,0 +1,1 @@
+ioapi/3.2	unstable	gcc/11.2.0 openmpi/4.1.3_slurm  hdf5/1.13.1_slurm netcdf/4.8.1 parallel-netcdf/1.12.3


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "ioapi/3.2 with gcc/11.2.0 openm...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/320) |
> | **GitLab MR Number** | [320](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/320) |
> | **Date Originally Opened** | Wed, 1 Jun 2022 |
> | **Date Originally Merged** | Mon, 4 Jul 2022 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #225