### PR TITLE
Add boost with impi/22.1. Move bvalidated boost versions to stable (and dependencies)

### DIFF
--- a/Compiler/impi/files/variants.rhel6
+++ b/Compiler/impi/files/variants.rhel6
@@ -10,6 +10,6 @@ impi/18.3       stable		intel/18.3
 impi/18.4       stable		intel/18.4
 impi/19.3       stable		intel/19.3
 impi/19.4	stable		intel/19.4
-impi/20.4	unstable	intel/20.4
-impi/21.4	unstable	intel/21.4
-impi/22.1	unstable	intel/22.1
+impi/20.4	stable	        intel/20.4
+impi/21.4	stable	        intel/21.4
+impi/22.1	stable	        intel/22.1

--- a/Compiler/openmpi/files/variants.merlin6
+++ b/Compiler/openmpi/files/variants.merlin6
@@ -37,7 +37,7 @@ openmpi/4.0.7-1_slurm   stable     gcc/10.2.0 cuda/11.4.3 b:ucx/1.11.2-1_slurm
 openmpi/4.1.1_slurm     unstable   gcc/10.2.0 cuda/11.3.0 b:ucx/1.11.2_slurm
 openmpi/4.1.1-1_slurm   unstable   gcc/10.2.0 cuda/11.3.0 b:ucx/1.10.0_slurm
 
-openmpi/4.1.3_slurm     unstable   gcc/{9.3.0,10.3.0,11.2.0} cuda/11.5.1 b:ucx/1.12.1_slurm
+openmpi/4.1.3_slurm     stable   gcc/{9.3.0,10.3.0,11.2.0} cuda/11.5.1 b:ucx/1.12.1_slurm
 
 openmpi/4.0.5-1_dgx     deprecated gcc/{8.4.0,9.3.0,10.2.0} cuda/11.2.2 b:ucx/1.10.0-1_dgx
 openmpi/4.1.0-1_dgx     deprecated gcc/10.2.0 cuda/11.2.2 b:ucx/1.10.0-1_dgx

--- a/Libraries/ucx/files/variants.merlin6
+++ b/Libraries/ucx/files/variants.merlin6
@@ -7,7 +7,7 @@ ucx/1.11.2-1_slurm        stable     cuda/11.4.3 b:doxygen/1.9.2  b:knem/1.1.4 b
 ucx/1.11.2-2_slurm        stable     cuda/11.5.1 b:doxygen/1.9.2  b:knem/1.1.4 b:GDRCopy/2.2.0
 ucx/1.11.2-3_slurm        stable     cuda/11.1.0 b:doxygen/1.9.2  b:knem/1.1.4 b:GDRCopy/2.2.0
 
-ucx/1.12.1_slurm          unstable   cuda/11.5.1 b:doxygen/1.9.2  b:knem/1.1.4 b:GDRCopy/2.2.0
+ucx/1.12.1_slurm          stable     cuda/11.5.1 b:doxygen/1.9.2  b:knem/1.1.4 b:GDRCopy/2.2.0
 
 ucx/1.9.0_dgx             deprecated cuda/11.1.0 b:doxygen/1.8.14 b:knem/1.1.4
 ucx/1.10.0-1_dgx          deprecated cuda/11.2.2 b:doxygen/1.8.14 b:knem/1.1.4 b:GDRCopy/2.2.0

--- a/MPI/boost/build
+++ b/MPI/boost/build
@@ -5,7 +5,12 @@ pbuild::set_download_url "https://boostorg.jfrog.io/artifactory/main/release/${V
 
 pbuild::add_to_group 'MPI'
 
-#pbuild::add_patch "files/context-Jamfile.patch"
+if (( V_MAJOR == 1 )); then
+  if (( V_MINOR >= 78 && V_MINOR < 80 )); then
+    pbuild::add_patch "files/intel-linux.patch"
+  fi
+fi
+
 
 BOOST_BUILD_PATH="${BUILD_DIR}"
 
@@ -16,29 +21,61 @@ pbuild::configure() {
 }
 
 pbuild::compile() {
+        cd "${SRC_DIR}"
+
 	case "${COMPILER}" in
 	gcc )
 	        TOOLSET=gcc
 	        ;;
 	intel )
-	        TOOLSET=intel-linux
-	        # TOOLSET=gcc
+                if (( V_MAJOR == 1 )); then
+                  if (( V_MINOR >= 75 )); then
+                    if (( V_MINOR < 78 )); then
+   	              TOOLSET=clang
+                    else
+	              TOOLSET=intel-linux
+                    fi
+                  else
+                    std::die 1 "Old version ${V_MAJOR}.${V_MINOR}.X not yet supported by PSI with intel compiler"
+                  fi
+                fi
 	        ;;
 	* )
 	        std::die 1 "Unsupported compiler!"
 	        ;;
 	esac
-        cd "${SRC_DIR}"
+
         ./bootstrap.sh \
                 --prefix="${PREFIX}" \
                 --with-toolset=${TOOLSET} \
                 --without-libraries=python \
                 || exit 1
+
+        case "${COMPILER}" in
+        intel )
+          if (( V_MAJOR == 1 )); then
+            if (( V_MINOR >= 75 )); then
+              if (( V_MINOR < 78 )); then
+                case "$IMPI_VERSION" in
+                "22.1" )
+                  sed -i "s#using clang.*#using clang : 2022.0.0.20211123 : $CMPLR_ROOT/linux/bin-llvm/clang++ ;#g" project-config.jam
+                  ;;
+                * )
+	          std::die 1 "Unsupported Intel compiler! Changes in the build file are required."
+	          ;;
+                esac
+              fi
+            fi
+          fi
+          ;;
+        esac
+
         echo "using mpi ;" >> "./project-config.jam"
         ./b2  \
                 --build-dir="${BUILD_DIR}" \
                 --layout=system \
                 --without-python \
+                -d+2 \
                 toolset=${TOOLSET} \
                 variant=release \
                 link=shared,static \

--- a/MPI/boost/files/intel-linux.patch
+++ b/MPI/boost/files/intel-linux.patch
@@ -1,0 +1,11 @@
+--- src/tools/build/src/tools/intel-linux.jam	        2022-04-06 23:02:49.000000000 +0200
++++ src.orig/tools/build/src/tools/intel-linux.jam	2022-08-04 17:09:15.222276601 +0200
+@@ -276,7 +276,7 @@
+ #
+ actions compile.c++.pch
+ {
+-    rm -f "$(<)" && LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -pch-create "$(<)" "$(>)"
++    rm -f "$(<)" && LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -Xclang -emit-pch -o "$(<)" "$(>)"
+ }
+ 
+ actions compile.fortran

--- a/MPI/boost/files/variants.merlin6
+++ b/MPI/boost/files/variants.merlin6
@@ -1,9 +1,10 @@
-boost/1.69.0_slurm	unstable 	intel/21.4 impi/21.4 b:zlib/1.2.11
+boost/1.69.0_slurm	stable 		intel/21.4 impi/21.4 b:zlib/1.2.11
 boost/1.70.0_slurm	stable		gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6_slurm b:zlib/1.2.11
 boost/1.73.0_slurm	stable		gcc/{7.5.0,8.4.0,9.3.0} openmpi/3.1.6_slurm b:zlib/1.2.11
 boost/1.73.0_slurm	stable		gcc/8.4.0 openmpi/4.0.5_slurm b:zlib/1.2.11
 boost/1.73.0-1_slurm	stable		gcc/{8.4.0,9.3.0,10.2.0} openmpi/4.0.5-1_slurm b:zlib/1.2.11
 boost/1.73.0_dgx	deprecated	gcc/{8.4.0,9.3.0,10.2.0} openmpi/4.0.5-1_dgx
+boost/1.75.0_slurm	unstable 	intel/22.1 impi/22.1 b:zlib/1.2.11
 boost/1.76.0_slurm      stable          gcc/{10.2.0,10.3.0} openmpi/4.0.5-1_slurm b:zlib/1.2.11
-boost/1.79.0_slurm	unstable	gcc/{9.3.0,10.3.0} openmpi/4.1.3_slurm b:zlib/1.2.11
-boost/1.79.0_slurm	unstable 	intel/21.4 impi/21.4 b:zlib/1.2.11
+boost/1.79.0_slurm	stable		gcc/{9.3.0,10.3.0} openmpi/4.1.3_slurm b:zlib/1.2.11
+boost/1.79.0_slurm	unstable 	intel/22.1 impi/22.1 b:zlib/1.2.11


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | caubet_m |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Add boost with impi/22.1. Move bvalidate...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/342) |
> | **GitLab MR Number** | [342](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/342) |
> | **Date Originally Opened** | Fri, 5 Aug 2022 |
> | **Date Originally Merged** | Fri, 5 Aug 2022 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_