### PR TITLE
Resolve "build openmpi/4.1.4 with gcc/10.4.0"

### DIFF
--- a/Compiler/openmpi/files/variants.rhel6
+++ b/Compiler/openmpi/files/variants.rhel6
@@ -50,3 +50,5 @@ openmpi/4.0.2	stable		gcc/9.2.0
 
 openmpi/4.0.5   stable		gcc/{7.5.0,8.4.0,9.3.0,10.2.0} ucx/1.8.1
 openmpi/4.0.5   stable		gcc/10.3.0
+
+openmpi/4.1.4   unstable	gcc/10.4.0


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "build openmpi/4.1.4 with gcc/10...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/363) |
> | **GitLab MR Number** | [363](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/363) |
> | **Date Originally Opened** | Wed, 2 Nov 2022 |
> | **Date Originally Merged** | Wed, 2 Nov 2022 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #247