### PR TITLE
Add new MotionCor2 variants

### DIFF
--- a/EM/MotionCor2/README.md
+++ b/EM/MotionCor2/README.md
@@ -6,6 +6,7 @@
 4. Move all executables to /opt/psi/EM/MotionCor2/$VERSION/bin
 5. Move user manual to /opt/psi/EM/MotionCor2/$VERSION/
 6. Fix permissions: chmod 755 /opt/psi/EM/MotionCor2/$VERSION/bin
+7. Create bin/MotionCor2 wrapper for each version
 
 
 ## Cuda versions

--- a/EM/MotionCor2/bin/MotionCor2
+++ b/EM/MotionCor2/bin/MotionCor2
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Script directory. Better than $MOTIONCOR2_HOME/bin since it can be called without loading modules.
+BIN="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+if [ -z ${CUDA_VERSION} ]; then 
+    echo 'MotionCor2 requires the cuda module. Run `module load cuda/<version>`' >&2
+    exit 1
+fi
+
+CUDA=$(echo "${CUDA_VERSION}" | sed -r 's/([0-9]+)\.([0-9]+)(\..*)/\1\2/')
+
+EXE=$(echo "$BIN"/MotionCor2_*_Cuda${CUDA}*)
+#echo "Running $EXE"
+
+if [ ! -x "$EXE" ]; then
+    echo "MotionCor2/$MOTIONCOR2_VERSION is not compatible with cuda/$CUDA_VERSION" >&2
+    exit 1
+fi
+
+exec "$EXE" "$@"

--- a/EM/MotionCor2/build
+++ b/EM/MotionCor2/build
@@ -18,5 +18,6 @@ pbuild::compile() {
 
 pbuild::install() {
     cp $BUILDBLOCK_DIR/files/LICENSE $PREFIX/
+    cp -r $BUILDBLOCK_DIR/bin $PREFIX/
 }
 

--- a/EM/MotionCor2/files/variants
+++ b/EM/MotionCor2/files/variants
@@ -8,3 +8,6 @@ MotionCor2/1.3.0	stable
 MotionCor2/1.3.1	stable	
 MotionCor2/1.3.2	stable	
 MotionCor2/1.4.0	stable	
+MotionCor2/1.4.5	stable	
+MotionCor2/1.4.7	unstable	
+MotionCor2/1.5.0	unstable	


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | bliven_s |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Add new MotionCor2 variants](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/370) |
> | **GitLab MR Number** | [370](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/370) |
> | **Date Originally Opened** | Thu, 10 Nov 2022 |
> | **Date Originally Merged** | Thu, 10 Nov 2022 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Also standardize the MotionCor2 wrapper so that it's the same for all
module versions regardless of cuda support