### PR TITLE
Resolve "HDF5_blosc: deprecate version compiled with a deprecated compiler"

### DIFF
--- a/HDF5_serial/HDF5_blosc/files/variants
+++ b/HDF5_serial/HDF5_blosc/files/variants
@@ -1,2 +1,2 @@
-HDF5_blosc/1.0.0_merlin    unstable    gcc/4.8.3 hdf5_serial/1.8.12 b:cmake/3.9.6
-HDF5_blosc/1.0.0_avx2    unstable    gcc/4.8.3 hdf5_serial/1.8.12 b:cmake/3.9.6
+HDF5_blosc/1.0.0_merlin	deprecated	gcc/4.8.3 hdf5_serial/1.8.12 b:cmake/3.9.6
+HDF5_blosc/1.0.0_avx2	deprecated	gcc/4.8.3 hdf5_serial/1.8.12 b:cmake/3.9.6


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "HDF5_blosc: deprecate version c...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/379) |
> | **GitLab MR Number** | [379](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/379) |
> | **Date Originally Opened** | Fri, 27 Jan 2023 |
> | **Date Originally Merged** | Fri, 27 Jan 2023 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #256