### PR TITLE
Release PEET 1.16.0

### DIFF
--- a/EM/PEET/files/variants
+++ b/EM/PEET/files/variants
@@ -1,1 +1,2 @@
-PEET/1.15.1a	unstable	gcc/9.5.0 matlab/2020b
+PEET/1.15.1a	stable	gcc/9.5.0 matlab/2020b
+PEET/1.16.0	unstable	gcc/9.5.0 matlab/2021b


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | bliven_s |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Release PEET 1.16.0](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/380) |
> | **GitLab MR Number** | [380](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/380) |
> | **Date Originally Opened** | Mon, 30 Jan 2023 |
> | **Date Originally Merged** | Mon, 30 Jan 2023 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Add unstable PEET/1.16.0
Mark PETT/1.15.1a as stable