### PR TITLE
Resolve "build modules for current gcc's"

### DIFF
--- a/Libraries/mpc/files/variants
+++ b/Libraries/mpc/files/variants
@@ -8,3 +8,4 @@ mpc/1.1.0-2	stable		b:gmp/6.1.2-1 b:mpfr/4.0.1-1
 mpc/1.1.0-3	stable		b:gmp/6.1.2-1 b:mpfr/4.0.2
 mpc/1.1.0-4	stable		b:gmp/6.2.0 b:mpfr/4.0.2-1
 mpc/1.2.1	stable		b:gmp/6.2.1 b:mpfr/4.1.0
+mpc/1.3.1	stable		b:gmp/6.2.1 b:mpfr/4.2.0

--- a/Libraries/mpfr/files/variants
+++ b/Libraries/mpfr/files/variants
@@ -9,3 +9,5 @@ mpfr/4.0.1-1	stable          b:gmp/6.1.2-1
 mpfr/4.0.2      stable          b:gmp/6.1.2-1
 mpfr/4.0.2-1    stable		b:gmp/6.2.0
 mpfr/4.0.2-2    stable		b:gmp/6.2.0
+mpfr/4.1.0	stable		b:gmp/6.2.1
+mpfr/4.2.0	stable		b:gmp/6.2.1

--- a/Programming/gcc/files/variants.rhel6
+++ b/Programming/gcc/files/variants.rhel6
@@ -41,3 +41,10 @@ gcc/10.3.0	stable		b:gmp/6.2.1 b:mpfr/4.1.0 b:mpc/1.2.1
 gcc/10.4.0	stable		b:gmp/6.2.1 b:mpfr/4.1.0 b:mpc/1.2.1
 
 gcc/11.2.0      stable          b:gcc/10.3.0 b:gmp/6.2.1 b:mpfr/4.1.0 b:mpc/1.2.1
+gcc/11.3.0	stable		b:gcc/10.3.0 b:gmp/6.2.1 b:mpfr/4.1.0 b:mpc/1.2.1
+gcc/11.4.0	stable		b:gcc/10.3.0 b:gmp/6.2.1 b:mpfr/4.2.0 b:mpc/1.3.1
+
+gcc/12.1.0	stable		b:gcc/11.3.0 b:gmp/6.2.1 b:mpfr/4.1.0 b:mpc/1.2.1
+gcc/12.3.0	stable		b:gcc/10.3.0 b:gmp/6.2.1 b:mpfr/4.2.0 b:mpc/1.3.1
+
+gcc/13.1.0	stable		b:gcc/10.4.0 b:gmp/6.2.1 b:mpfr/4.2.0 b:mpc/1.3.1


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "build modules for current gcc's...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/405) |
> | **GitLab MR Number** | [405](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/405) |
> | **Date Originally Opened** | Thu, 22 Jun 2023 |
> | **Date Originally Merged** | Thu, 13 Jul 2023 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #264