### PR TITLE
Resolve "fftw 3.3.10 for merlin with gcc/10.4.0 and openmpi/4.1.5_merlin6"

### DIFF
--- a/MPI/fftw/files/variants.merlin6
+++ b/MPI/fftw/files/variants.merlin6
@@ -1,0 +1,10 @@
+fftw/3.3.8		deprecated	gcc/{7.3.0,8.2.} openmpi/3.1.3
+fftw/3.3.8-1_dp_merlin	deprecated	gcc/8.2.0 openmpi/3.1.1
+fftw/3.3.8-1_dp_merlin6	deprecated	gcc/{7.4.0,8.3.0} openmpi/3.1.4_merlin6
+fftw/3.3.8-1_sp_merlin	deprecated	gcc/8.2.0 openmpi/3.1.1
+fftw/3.3.8-1_sp_merlin6	deprecated	gcc/{7.4.0,8.3.0} openmpi/3.1.4_merlin6
+fftw/3.3.9_merlin6	unstable	gcc/{8.4.0,9.3.0,10.2.0,10.3.0,11.2.0} openmpi/4.0.5-1_slurm
+fftw/3.3.10		unstable	gcc/{7.5.0,8.4.0,9.3.0,10.3.0} openmpi/4.0.5
+fftw/3.3.10_merlin6	unstable	gcc/{8.4.0,9.3.0,10.2.0,10.3.0,11.2.0} openmpi/4.0.5-1_slurm
+
+fftw/3.3.10_merlin6	unstable	gcc/10.4.0 openmpi/4.1.5_slurm


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Resolve "fftw 3.3.10 for merlin with gcc...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/408) |
> | **GitLab MR Number** | [408](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/408) |
> | **Date Originally Opened** | Mon, 10 Jul 2023 |
> | **Date Originally Merged** | Mon, 10 Jul 2023 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #266