### PR TITLE
Set MotionCor2 path based on the loaded cuda version.

### DIFF
--- a/EM/relion/modulefile
+++ b/EM/relion/modulefile
@@ -44,4 +44,22 @@ setenv RELION_RESMAP_EXECUTABLE /opt/psi/EM/ResMap/1.1.4/bin/ResMap
 
 # Version-specific variables
 setenv RELION_QSUB_TEMPLATE /opt/psi/EM/relion/$V/scripts/multi_gpu.sh
-setenv RELION_MOTIONCOR2_EXECUTABLE /opt/psi/EM/MotionCor2/1.4.0/bin/MotionCor2
+
+# See MC2 compatibility matrix: https://intranet.psi.ch/en/bio/motioncor2
+if {[string match "8.0*" $env(CUDA_VERSION)]} {
+    setenv RELION_MOTIONCOR2_EXECUTABLE "/opt/psi/EM/MotionCor2/1.3.2/bin/MotionCor2_1.3.2-Cuda80"
+} elseif {[string match "11.0*" $env(CUDA_VERSION)]} {
+    setenv RELION_MOTIONCOR2_EXECUTABLE "/opt/psi/EM/MotionCor2/1.4.0/bin/MotionCor2"
+} else {
+    setenv RELION_MOTIONCOR2_EXECUTABLE "/opt/psi/EM/MotionCor2/1.6.4/bin/MotionCor2"
+}
+
+# relion 5 features
+if {[file exists /opt/psi/EM/relion/$V/conda_env/$V]} {
+    setenv RELION_TOPAZ_EXECUTABLE /opt/psi/EM/relion/$V/conda_env/$V/bin/topaz
+    setenv RELION_PYTHON_EXECUTABLE /opt/psi/EM/relion/$V/conda_env/$V/bin/python
+}
+if {[file exists /opt/psi/EM/relion/$V/torch]} {
+    setenv RELION_TORCH_HOME_PATH /opt/psi/EM/relion/$V/torch
+}
+


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | bliven_s |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Set MotionCor2 path based on the loaded ...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/432) |
> | **GitLab MR Number** | [432](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/432) |
> | **Date Originally Opened** | Tue, 2 Apr 2024 |
> | **Date Originally Merged** | Wed, 3 Apr 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Fixes #275.

This does not require the MotionCor2 module to be loaded, but rather hard-codes it based on the cuda version. This may require updating the relion modulefile following future MotionCor2 releases. However, it avoids adding specific MotionCor2 versions as dependencies of relion.

Note when testing that these environmental variables only set defaults, and may be overridden by project-specific or job-specific settings.

This PR does NOT include changes to the variants file. @assman_g please push the 5.0-beta and 5.0-sp variants as a separate PR. Hopefully this modulefile should be compatible with all versions.