### PR TITLE
Release datacatalog 2.2.1

### DIFF
--- a/Tools/datacatalog/README.md
+++ b/Tools/datacatalog/README.md
@@ -6,7 +6,7 @@ This module provides tools to interface with the Data Catalog (discovery.psi.ch)
 
 ## Version Numbers
 
-Prior to version 2, each command had it's own version. The pmodule version
+Prior to version 2, each command had its own version. The pmodule version
 roughly tracked the datasetIngestor version. However, some pmodules were
 updated manually with more recent binaries, so in general there is no way to
 check the versions contained in older pmodules other than running each command
@@ -42,7 +42,6 @@ fixed with a manual wrapper script which produces an error on RHEL 8.
 
 # TODO
 
-- [ ] The post_prep section of the build script should be removed following
-  fixing [#55](https://github.com/paulscherrerinstitute/scicat-cli/issues/55)
-- [ ] SciCat should be downloaded and installed in the build script
+- [ ] SciCat should be downloaded and installed in the build script. (This is
+      planned after the GUI is migrated to github and CI/CD implemented.)
 

--- a/Tools/datacatalog/build
+++ b/Tools/datacatalog/build
@@ -1,17 +1,7 @@
 #!/usr/bin/env modbuild
 
 pbuild::add_to_group 'Tools'
-pbuild::set_download_url https://github.com/paulscherrerinstitute/scicat-cli/releases/download/v${V_PKG}/scicat-cli_.${V_PKG}_Linux_x86_64.tar.gz
-
-pbuild::post_prep() {
-  # PModules 1.0.0 fails on tar bundles without top-level directories. This
-  # tries to work around this.  It could be removed if the cli release process
-  # changes (https://github.com/paulscherrerinstitute/scicat-cli/issues/55)
-  if [[ ! -f "${SRC_DIR}/datasetIngestor" ]]; then
-    local file="$PMODULES_DISTFILESDIR/scicat-cli_.${V_PKG}_Linux_x86_64.tar.gz"
-    tar --directory="${SRC_DIR}" -xv --strip-components 0 -f "${file}"
-  fi
-}
+pbuild::set_download_url https://github.com/paulscherrerinstitute/scicat-cli/releases/download/v${V_PKG}/scicat-cli_v${V_PKG}_Linux_x86_64.tar.gz
 
 pbuild::configure() {
   :

--- a/Tools/datacatalog/files/variants.Linux
+++ b/Tools/datacatalog/files/variants.Linux
@@ -7,3 +7,4 @@ datacatalog/1.1.15	removed
 datacatalog/1.1.10	deprecated
 datacatalog/1.1.11	deprecated
 datacatalog/2.2.0	stable
+datacatalog/2.2.1	stable


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | bliven_s |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Release datacatalog 2.2.1](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/442) |
> | **GitLab MR Number** | [442](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/442) |
> | **Date Originally Opened** | Mon, 3 Jun 2024 |
> | **Date Originally Merged** | Mon, 3 Jun 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Features:
- SciCat GUI works on RHEL8
- Updates download URL and untar procedure