### PR TITLE
move anaconda_2024.08 to stable

### DIFF
--- a/Programming/anaconda/files/config.yaml
+++ b/Programming/anaconda/files/config.yaml
@@ -12,4 +12,4 @@ anaconda:
           - url: https://repo.anaconda.com/miniconda/Miniconda3-py39_24.5.0-0-Linux-x86_64.sh
             name: miniconda-2024.08.sh
             unpacker: none
-        relstage: unstable
+        relstage: stable


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | feichtinger |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [move anaconda_2024.08 to stable](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/485) |
> | **GitLab MR Number** | [485](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/485) |
> | **Date Originally Opened** | Thu, 24 Apr 2025 |
> | **Date Originally Merged** | Thu, 24 Apr 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

move anaconda_2024.08 to stable