### PR TITLE
Release datacatalog 2.2.2 and 3.0.0-alpha7

### DIFF
--- a/Tools/datacatalog/build
+++ b/Tools/datacatalog/build
@@ -1,7 +1,8 @@
 #!/usr/bin/env modbuild
 
 pbuild::add_to_group 'Tools'
-pbuild::set_download_url https://github.com/paulscherrerinstitute/scicat-cli/releases/download/v${V_PKG}/scicat-cli_v${V_PKG}_Linux_x86_64.tar.gz
+pbuild::set_download_url https://github.com/paulscherrerinstitute/scicat-cli/releases/download/v${V}/scicat-cli_${V}_Linux_x86_64.tar.gz
+
 
 pbuild::configure() {
   :

--- a/Tools/datacatalog/files/variants.Linux
+++ b/Tools/datacatalog/files/variants.Linux
@@ -8,3 +8,6 @@ datacatalog/1.1.10	deprecated
 datacatalog/1.1.11	deprecated
 datacatalog/2.2.0	stable
 datacatalog/2.2.1	stable
+datacatalog/2.2.2	stable
+datacatalog/3.0.0-alpha7	unstable
+


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | bliven_s |
> | **GitLab Project** | [Pmodules/buildblocks](https://gitlab.psi.ch/Pmodules/buildblocks) |
> | **GitLab Merge Request** | [Release datacatalog 2.2.2 and 3.0.0-alph...](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/527) |
> | **GitLab MR Number** | [527](https://gitlab.psi.ch/Pmodules/buildblocks/merge_requests/527) |
> | **Date Originally Opened** | Mon, 29 Sep 2025 |
> | **Date Originally Merged** | Mon, 29 Sep 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Add datacatalog/2.2.2 and 3.0.0-alpha7