### PR TITLE
Add Entrez Direct v24.0

### DIFF
--- a/EM/edirect/README.md
+++ b/EM/edirect/README.md
@@ -1,0 +1,5 @@
+# Entrez Direct
+
+Entrez Direct (EDirect) is an advanced method for accessing the NCBI's set of interconnected databases (publication, sequence, structure, gene, variation, expression, etc.) from a UNIX terminal window. Functions take search terms from command-line arguments. Individual operations are combined to build multi-step queries. Record retrieval and formatting normally complete the process.
+
+https://www.ncbi.nlm.nih.gov/books/NBK179288/

--- a/EM/edirect/build
+++ b/EM/edirect/build
@@ -1,0 +1,29 @@
+#!/usr/bin/env modbuild
+
+pbuild::configure() {
+    # Install Miniforge
+    mkdir -p "$PREFIX/miniforge"
+    wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O "$PREFIX/miniforge/miniforge.sh"
+    bash "$PREFIX/miniforge/miniforge.sh" -b -u -p "$PREFIX/miniforge/"
+
+    # Initialize conda for script use
+    source "$PREFIX/miniforge/etc/profile.d/conda.sh"
+
+    # Create the conda environment
+    conda create -y --name "${P}_${V_PKG}"
+}
+
+pbuild::compile() {
+    :
+}
+
+pbuild::install() {
+    # Ensure conda is initialized
+    source "$PREFIX/miniforge/etc/profile.d/conda.sh"
+
+    # Activate the conda environment
+    conda activate "${P}_${V_PKG}"
+
+    # Install required packages
+    conda install -y bioconda::entrez-direct="${V_PKG}"
+}

--- a/EM/edirect/files/config.yaml
+++ b/EM/edirect/files/config.yaml
@@ -1,0 +1,14 @@
+---
+format: 1
+edirect:
+  defaults:
+    group: EM
+    overlay: base
+    relstage: stable
+
+  versions:
+    24.0:
+      variants:
+        - overlay: Alps
+          systems: [.*.merlin7.psi.ch]
+          relstage: stable

--- a/EM/edirect/modulefile
+++ b/EM/edirect/modulefile
@@ -1,0 +1,18 @@
+#%Module1.0
+
+module-whatis       "An advanced method for accessing the NCBI's set of interconnected databases."
+module-url          "https://www.ncbi.nlm.nih.gov/books/NBK179288/"
+module-license      ""
+module-maintainer   "João Pedro Agostinho de Sousa <joao.agostinho-de-sousa@psi.ch>"
+
+module-help         "
+Entrez Direct (EDirect) provides access to Entrez, the NCBI's suite of
+interconnected databases (publication, sequence, structure, gene, variation,
+expression, etc.) from a Unix terminal window. Search terms are entered as
+command-line arguments. Individual operations are connected with Unix pipes to
+construct multi-step queries. Selected records can then be retrieved in a
+variety of formats.
+"
+
+# Add conda env bin directory to PATH
+prepend-path PATH "${PREFIX}/miniforge/envs/${P}_${V_PKG}/bin"


### PR DESCRIPTION
Entrez Direct (EDirect) is an advanced method for accessing the NCBI's set of interconnected databases (publication, sequence, structure, gene, variation, expression, etc.) from a UNIX terminal window. Functions take search terms from command-line arguments. Individual operations are combined to build multi-step queries. Record retrieval and formatting normally complete the process.

https://www.ncbi.nlm.nih.gov/books/NBK179288/