### PR TITLE
Add libjpeg-turbo 3.1.2

### DIFF
--- a/Libraries/libjpeg-turbo/README.md
+++ b/Libraries/libjpeg-turbo/README.md
@@ -1,0 +1,5 @@
+# libjpeg-turbo
+
+libjpeg-turbo is a JPEG image codec that uses SIMD instructions to accelerate baseline JPEG compression and decompression on x86, x86-64, Arm, PowerPC, and MIPS systems, as well as progressive JPEG compression on x86, x86-64, and Arm systems. On such systems, libjpeg-turbo is generally 2-6x as fast as libjpeg, all else being equal. On other types of systems, libjpeg-turbo can still outperform libjpeg by a significant amount, by virtue of its highly-optimized Huffman coding routines. In many cases, the performance of libjpeg-turbo rivals that of proprietary high-speed JPEG codecs.
+
+https://github.com/libjpeg-turbo/libjpeg-turbo

--- a/Libraries/libjpeg-turbo/build
+++ b/Libraries/libjpeg-turbo/build
@@ -1,0 +1,2 @@
+#!/usr/bin/env modbuild
+

--- a/Libraries/libjpeg-turbo/files/config.yaml
+++ b/Libraries/libjpeg-turbo/files/config.yaml
@@ -1,0 +1,32 @@
+---
+# yamllint disable rule:line-length
+format: 1
+libjpeg-turbo:
+  defaults:
+    group: Libraries
+    overlay: base
+    relstage: stable
+    urls:
+      - url: https://github.com/${P}/${P}/releases/download/${V_PKG}/${P}-${V_PKG}.tar.gz
+
+  shasums:
+    libjpeg-turbo-3.1.2.tar.gz: 8f0012234b464ce50890c490f18194f913a7b1f4e6a03d6644179fa0f867d0cf
+
+  versions:
+    3.1.2:
+      variants:
+        - overlay: base
+          target_cpus: [x86_64]
+          systems: [.*.merlin7.psi.ch]
+          relstage: stable
+          build_requires:
+            - gcc/12.3.0
+            - cmake/3.26.3
+            - openjdk/25.0.1
+        - overlay: base
+          target_cpus: [aarch64]
+          systems: [gpu0.*.merlin7.psi.ch]
+          relstage: stable
+          build_requires:
+            - gcc/12.3.0
+            - openjdk/25.0.1

--- a/Libraries/libjpeg-turbo/modulefile
+++ b/Libraries/libjpeg-turbo/modulefile
@@ -1,0 +1,16 @@
+#%Module1.0
+
+module-whatis       "libjpeg-turbo is a JPEG image codec that uses SIMD instructions to accelerate baseline JPEG compression and decompression"
+module-url          "https://github.com/libjpeg-turbo/libjpeg-turbo"
+module-license      "IJG (Independent JPEG Group) License and Modified (3-clause) BSD License (https://github.com/libjpeg-turbo/libjpeg-turbo?tab=License-1-ov-file#readme)"
+module-maintainer   "João Pedro Agostinho de Sousa <joao.agostinho-de-sousa@psi.ch>"
+module-help "
+libjpeg-turbo is a JPEG image codec that uses SIMD instructions to accelerate
+baseline JPEG compression and decompression on x86, x86-64, Arm, PowerPC, and
+MIPS systems, as well as progressive JPEG compression on x86, x86-64, and Arm
+systems. On such systems, libjpeg-turbo is generally 2-6x as fast as libjpeg,
+all else being equal. On other types of systems, libjpeg-turbo can still
+outperform libjpeg by a significant amount, by virtue of its highly-optimized
+Huffman coding routines. In many cases, the performance of libjpeg-turbo rivals
+that of proprietary high-speed JPEG codecs.
+"


### PR DESCRIPTION
libjpeg-turbo is a JPEG image codec that uses SIMD instructions to accelerate baseline JPEG compression and decompression on x86, x86-64, Arm, PowerPC, and MIPS systems, as well as progressive JPEG compression on x86, x86-64, and Arm systems. On such systems, libjpeg-turbo is generally 2-6x as fast as libjpeg, all else being equal. On other types of systems, libjpeg-turbo can still outperform libjpeg by a significant amount, by virtue of its highly-optimized Huffman coding routines. In many cases, the performance of libjpeg-turbo rivals that of proprietary high-speed JPEG codecs.

https://github.com/libjpeg-turbo/libjpeg-turbo