### PR TITLE
Add rstudio-server v2025.09.2-418

### DIFF
--- a/Tools/rstudio-server/README.md
+++ b/Tools/rstudio-server/README.md
@@ -1,0 +1,7 @@
+# rstudio-server
+
+RStudio Server enables you to provide a browser-based interface to a version of
+R running on a remote Linux server, bringing the power and productivity of the
+RStudio IDE to server-based deployments of R.
+
+https://posit.co/products/open-source/rstudio-server/

--- a/Tools/rstudio-server/build
+++ b/Tools/rstudio-server/build
@@ -1,0 +1,34 @@
+#!/usr/bin/env modbuild
+
+pbuild::configure() {
+    # Detect OS
+    source /etc/os-release
+    echo "Detected OS: $ID ($VERSION_ID)"
+
+    if [[ "$ID" == "sles" && "${VERSION_ID%%.*}" == "15" ]]; then
+        OS_VERSION="opensuse15"
+    else
+        echo "Unsupported OS: $ID ($VERSION_ID)"
+        exit 1
+    fi
+
+    # Download RPM
+    FILE="rstudio-server-${V}-$(uname -i).rpm"
+    URL="https://download2.rstudio.org/server/${OS_VERSION}/$(uname -i)/${FILE}"
+    wget -q -O "${SRC_DIR}/${FILE}" "$URL"
+
+    # Extract using rpm2cpio
+    cd "$SRC_DIR" || exit 1
+    rpm2cpio "$FILE" | cpio -idmv
+
+    # Extract to $PREFIX
+    cp -r "${SRC_DIR}/usr/lib/rstudio-server/" "$PREFIX/"
+}
+
+pbuild::compile(){
+    :
+}
+
+pbuild::install(){
+    :
+}

--- a/Tools/rstudio-server/files/config.yaml
+++ b/Tools/rstudio-server/files/config.yaml
@@ -1,0 +1,15 @@
+---
+format: 1
+rstudio-server:
+  defaults:
+    group: Tools
+    overlay: base
+    relstage: stable
+
+  versions:
+    2025.09.2-418:
+      variants:
+        - overlay: base
+          target_cpus: [x86_64]
+          systems: [.*.merlin7.psi.ch]
+          relstage: stable

--- a/Tools/rstudio-server/modulefile
+++ b/Tools/rstudio-server/modulefile
@@ -1,0 +1,12 @@
+#%Module1.0
+
+module-whatis       "RStudio is an integrated development environment (IDE) for the R programming language"
+module-url          "https://posit.co/products/open-source/rstudio-server/"
+module-license      "GNU Affero General Public License"
+module-maintainer   "João Pedro Agostinho de Sousa <joao.agostinho-de-sousa@psi.ch>"
+
+module-help "
+RStudio Server enables you to provide a browser-based interface to a version of
+R running on a remote Linux server, bringing the power and productivity of the
+RStudio IDE to server-based deployments of R.
+"


### PR DESCRIPTION
RStudio Server enables you to provide a browser-based interface to a version of
R running on a remote Linux server, bringing the power and productivity of the
RStudio IDE to server-based deployments of R.

https://posit.co/products/open-source/rstudio-server/