### PR TITLE
Add hmmer v3.4

### DIFF
--- a/EM/hmmer/README.md
+++ b/EM/hmmer/README.md
@@ -1,0 +1,7 @@
+# HMMER
+
+HMMER is used for searching sequence databases for sequence homologs, and for making sequence alignments. It implements methods using probabilistic models called profile hidden Markov models (profile HMMs).
+
+HMMER is often used together with a profile database, such as Pfam or many of the databases that participate in Interpro. But HMMER can also work with query sequences, not just profiles, just like BLAST. For example, you can search a protein query sequence against a database with phmmer, or do an iterative search with jackhmmer.
+
+HMMER is designed to detect remote homologs as sensitively as possible, relying on the strength of its underlying probability models. In the past, this strength came at significant computational expense, but as of the new HMMER3 project, HMMER is now essentially as fast as BLAST.

--- a/EM/hmmer/build
+++ b/EM/hmmer/build
@@ -1,0 +1,1 @@
+#!/usr/bin/env modbuild

--- a/EM/hmmer/files/config.yaml
+++ b/EM/hmmer/files/config.yaml
@@ -1,0 +1,25 @@
+---
+# yamllint disable rule:line-length
+format: 1
+hmmer:
+  defaults:
+    group: EM
+    overlay: base
+    relstage: stable
+    urls:
+      - url: http://eddylab.org/software/${P}/${P}-${V_PKG}.tar.gz
+
+  shasums:
+    hmmer-3.4.tar.gz: ca70d94fd0cf271bd7063423aabb116d42de533117343a9b27a65c17ff06fbf3 
+
+  versions:
+    3.4:
+      variants:
+        - overlay: Alps
+          target_cpus: [x86_64]
+          systems: [.*.merlin7.psi.ch]
+          relstage: stable
+        - overlay: Alps
+          target_cpus: [aarch64]
+          systems: [gpu0.*.merlin7.psi.ch]
+          relstage: stable

--- a/EM/hmmer/modulefile
+++ b/EM/hmmer/modulefile
@@ -1,0 +1,20 @@
+#%Module1.0
+
+module-whatis       "HMMER: biosequence analysis using profile hidden Markov models"
+module-url          "http://hmmer.org"
+module-license      "BSD License (https://github.com/EddyRivasLab/hmmer?tab=License-1-ov-file)"
+module-maintainer   "João Pedro Agostinho de Sousa <joao.agostinho-de-sousa@psi.ch>"
+
+module-help "
+HMMER is used for searching sequence databases for sequence homologs, and for
+making sequence alignments. It implements methods using probabilistic models
+called profile hidden Markov models (profile HMMs). HMMER is often used
+together with a profile database, such as Pfam or many of the databases that
+participate in Interpro. But HMMER can also work with query sequences, not just
+profiles, just like BLAST. For example, you can search a protein query sequence
+against a database with phmmer, or do an iterative search with jackhmmer. HMMER
+is designed to detect remote homologs as sensitively as possible, relying on
+the strength of its underlying probability models. In the past, this strength
+came at significant computational expense, but as of the new HMMER3 project,
+HMMER is now essentially as fast as BLAST.
+"


### PR DESCRIPTION
# HMMER

HMMER is used for searching sequence databases for sequence homologs, and for making sequence alignments. It implements methods using probabilistic models called profile hidden Markov models (profile HMMs).