### PR TITLE
RELION: Fix the scratch directory to avoid other jobs overwriting files

### DIFF
--- a/EM/relion/modulefile
+++ b/EM/relion/modulefile
@@ -40,7 +40,7 @@ if { $arch == "aarch64" && $V == "5.0.0-perf" } {
 # --------------------------------------------------------------------------
 setenv RELION_MPI_MAX                        16
 setenv RELION_THREAD_MAX                     36
-setenv RELION_SCRATCH_DIR                    /scratch
+setenv RELION_SCRATCH_DIR                    /scratch/$USER/$SLURM_JOB_ID
 setenv RELION_QUEUE_USE                      yes
 setenv RELION_QSUB_COMMAND                   sbatch
 setenv RELION_QUEUE_NAME                     daily


### PR DESCRIPTION
Since the scratch directory was only set to /scratch, if another job was writing the same type of files to scratch, I would overwriting the files from the previous job and, subsequently, the job would be cancelled for not finding the correct files.
As a solution, I replace the scratch directory to /scratch/$USER/$SLURM_JOB_ID to make them unique for each user and job.