### PR TITLE
Add Boltz v2.2.1

### DIFF
--- a/EM/boltz/build
+++ b/EM/boltz/build
@@ -1,5 +1,7 @@
 #!/usr/bin/env modbuild
 
+: "${PYTHON_VERSION:=3.12}"
+
 pbuild::configure() {
     # Install Miniforge
     mkdir -p "$PREFIX/miniforge"
@@ -10,7 +12,7 @@ pbuild::configure() {
     source "$PREFIX/miniforge/etc/profile.d/conda.sh"
 
     # Create the conda environment
-    conda create -y --name "${P}_${V_PKG}" python=3.12
+    conda create -y --name "${P}_${V_PKG}" "python=${PYTHON_VERSION}"
 }
 
 pbuild::compile() {
@@ -29,8 +31,7 @@ pbuild::install() {
 
     # Install the package using pip within the conda environment
     if [[ $(uname -m) == "aarch64" ]]; then
-        pip install --no-cache-dir torch torchvision torchaudio triton --index-url https://download.pytorch.org/whl/cu124
+        pip install --no-cache-dir torch torchvision torchaudio triton --index-url https://download.pytorch.org/whl/cu129
     fi
     pip install --no-cache-dir ".[cuda]"
-    pip install pytorch-lightning==2.5.0.post0
 }

--- a/EM/boltz/files/config.yaml
+++ b/EM/boltz/files/config.yaml
@@ -10,24 +10,22 @@ boltz:
       - url: https://github.com/jwohlwend/${P}/archive/refs/tags/v${V_PKG}.tar.gz
 
   shasums:
-    v2.2.0.tar.gz: 7671d361ce6f90818956d32867fb9c96c065730e5784e628eb9f774a8bcc0320
+    v2.2.1.tar.gz: dfbc5847a9d378a1e24829ff53c3faa182fb945775074712c130a3884710736d
 
   versions:
-    2.2.0:
+    2.2.1:
       variants:
         - overlay: Alps
           target_cpus: [x86_64]
-          systems: [.*.merlin7.psi.ch]
           relstage: stable
           build_requires:
-            - cuda/12.8.1
+            - cuda/12.9.1
           runtime_deps:
-            - cuda/12.8.1
+            - cuda/12.9.1
         - overlay: Alps
           target_cpus: [aarch64]
-          systems: [gpu0.*.merlin7.psi.ch]
           relstage: unstable
           build_requires:
-            - cuda/12.8.1
+            - cuda/12.9.1
           runtime_deps:
-            - cuda/12.8.1
+            - cuda/12.9.1


### PR DESCRIPTION
The previous version (2.2.0) was having issues with the python packages not being the expected version by Boltz. I decided to replace it with version 2.2.1 and the installation and running in both A100 and GH nodes was successful.