### PR TITLE
Add boltz version 2.2.0

### DIFF
--- a/EM/boltz/build
+++ b/EM/boltz/build
@@ -9,10 +9,10 @@ pbuild::configure() {
     bash "$PREFIX/miniforge/miniforge.sh" -b -u -p "$PREFIX/miniforge/"
 
     # Initialize conda for script use
-    source "$PREFIX/miniforge/etc/profile.d/conda.sh"
+    source "$PREFIX/miniforge/etc/profile.d/mamba.sh"
 
     # Create the conda environment
-    conda create -y --name "${P}_${V_PKG}" "python=${PYTHON_VERSION}"
+    mamba create -y --name "${P}_${V_PKG}" "python=${PYTHON_VERSION}"
 }
 
 pbuild::compile() {
@@ -21,17 +21,17 @@ pbuild::compile() {
 
 pbuild::install() {
     # Ensure conda is initialized
-    source "$PREFIX/miniforge/etc/profile.d/conda.sh"
+    source "$PREFIX/miniforge/etc/profile.d/mamba.sh"
 
     # Activate the conda environment
-    conda activate "${P}_${V_PKG}"
+    mamba activate "${P}_${V_PKG}"
 
     # Set the source directory
     cd "$SRC_DIR"
 
     # Install the package using pip within the conda environment
     if [[ $(uname -m) == "aarch64" ]]; then
-        pip install --no-cache-dir torch torchvision torchaudio triton --index-url https://download.pytorch.org/whl/cu129
+        pip install torch torchvision torchaudio triton --index-url https://download.pytorch.org/whl/cu129
     fi
-    pip install --no-cache-dir ".[cuda]"
+    pip install ".[cuda]"
 }

--- a/EM/boltz/files/config.yaml
+++ b/EM/boltz/files/config.yaml
@@ -10,9 +10,26 @@ boltz:
       - url: https://github.com/jwohlwend/${P}/archive/refs/tags/v${V_PKG}.tar.gz
 
   shasums:
+    v2.2.0.tar.gz: 7671d361ce6f90818956d32867fb9c96c065730e5784e628eb9f774a8bcc0320 
     v2.2.1.tar.gz: dfbc5847a9d378a1e24829ff53c3faa182fb945775074712c130a3884710736d
 
   versions:
+    2.2.0:
+      variants:
+        - overlay: Alps
+          target_cpus: [x86_64]
+          relstage: stable
+          build_requires:
+            - cuda/12.9.1
+          runtime_deps:
+            - cuda/12.9.1
+        - overlay: Alps
+          target_cpus: [aarch64]
+          relstage: unstable
+          build_requires:
+            - cuda/12.9.1
+          runtime_deps:
+            - cuda/12.9.1
     2.2.1:
       variants:
         - overlay: Alps


### PR DESCRIPTION
Added version 2.2.0 and made some changes to the build. For example, removed --no-cache-dir to take advantage of cached packages and replaced conda with mamba to speed up the installation process.