### PR TITLE
Add dssp version 4.5.6

### DIFF
--- a/EM/dssp/README.md
+++ b/EM/dssp/README.md
@@ -1,0 +1,5 @@
+# DSSP
+
+The DSSP program was designed by Wolfgang Kabsch and Chris Sander to standardize secondary structure assignment. DSSP is a database of secondary structure assignments (and much more) for all protein entries in the Protein Data Bank (PDB). DSSP is also the program that calculates DSSP entries from PDB entries. DSSP does not predict secondary structure.
+
+https://github.com/PDB-REDO/dssp

--- a/EM/dssp/build
+++ b/EM/dssp/build
@@ -1,0 +1,26 @@
+#!/usr/bin/env modbuild
+
+pbuild::pre_configure() {
+    :
+}
+
+pbuild::configure() {
+    :
+}
+
+pbuild::compile() {
+    :
+}
+
+pbuild::install() {
+    cd "${SRC_DIR}"
+
+    cmake -S . -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=$(which gcc) \
+    -DCMAKE_CXX_COMPILER=$(which g++) \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX}
+
+    cmake --build build -j8
+    cmake --install build
+}

--- a/EM/dssp/files/config.yaml
+++ b/EM/dssp/files/config.yaml
@@ -1,0 +1,33 @@
+---
+# yamllint disable rule:line-length
+format: 1
+dssp:
+  defaults:
+    group: EM
+    overlay: base
+    relstage: stable
+    urls:
+      - url: https://github.com/PDB-REDO/${P}/archive/refs/tags/v${V_PKG}.tar.gz
+
+  shasums:
+    v4.5.6.tar.gz: 940062a5c97be30546af045020761dbba68d4ca64cbaf2343b3765c0bf1f10b3
+
+  versions:
+    4.5.6:
+      variants:
+        - overlay: Alps
+          target_cpus: [x86_64]
+          systems: [.*.merlin7.psi.ch]
+          relstage: stable
+          build_requires:
+            - gcc/14.3.0
+          runtime_deps:
+            - gcc/14.3.0
+        - overlay: Alps
+          target_cpus: [aarch64]
+          systems: [gpu0.*.merlin7.psi.ch]
+          relstage: stable
+          build_requires:
+            - gcc/14.3.0
+          runtime_deps:
+            - gcc/14.3.0

--- a/EM/dssp/modulefile
+++ b/EM/dssp/modulefile
@@ -1,0 +1,14 @@
+#%Module1.0
+
+module-whatis       "The DSSP program was designed to standardize secondary structure assignment"
+module-url          "https://github.com/PDB-REDO/dssp"
+module-license	    "BSD-2-Clause license"
+module-maintainer   "Joao Pedro Agostinho de Sousa <joao.agostinho-de-sousa@psi.ch>"
+
+module-help         "
+The DSSP program was designed by Wolfgang Kabsch and Chris Sander to
+standardize secondary structure assignment. DSSP is a database of secondary
+structure assignments (and much more) for all protein entries in the Protein
+Data Bank (PDB). DSSP is also the program that calculates DSSP entries from PDB
+entries. DSSP does not predict secondary structure.
+"


### PR DESCRIPTION
The DSSP program was designed by Wolfgang Kabsch and Chris Sander to standardize secondary structure assignment. DSSP is a database of secondary structure assignments (and much more) for all protein entries in the Protein Data Bank (PDB). DSSP is also the program that calculates DSSP entries from PDB entries. DSSP does not predict secondary structure.

https://github.com/PDB-REDO/dssp