### PR TITLE
Remove the dependency virtualgl

### DIFF
--- a/Tools/vmd/files/config.yaml
+++ b/Tools/vmd/files/config.yaml
@@ -17,8 +17,6 @@ vmd:
           build_requires:
             - gcc/12.3.0
             - cuda/12.9.1
-            - virtualgl/3.1.4
           runtime_deps:
             - gcc/12.3.0
             - cuda/12.9.1
-            - virtualgl/3.1.4


### PR DESCRIPTION
I removed the dependency virtualGL because it was not necessary to run VMD.