### PR TITLE
Correct modulefile to prepend the ld library path

### DIFF
--- a/Tools/vmd/files/config.yaml
+++ b/Tools/vmd/files/config.yaml
@@ -17,6 +17,8 @@ vmd:
           build_requires:
             - gcc/12.3.0
             - cuda/12.9.1
+            - virtualgl/3.1.4
           runtime_deps:
             - gcc/12.3.0
             - cuda/12.9.1
+            - virtualgl/3.1.4

--- a/Tools/vmd/modulefile
+++ b/Tools/vmd/modulefile
@@ -24,5 +24,5 @@ setenv VMDDIR   $PREFIX
 if { $V == "2.0.0a8" } {
     setenv TCL_LIBRARY      $PREFIX/tcl/lib/tcl8.6
     setenv TK_LIBRARY       $PREFIX/tk/lib/tk8.6
-    setenv LD_LIBRARY_PATH  $PREFIX/lib/redistrib/lib_LINUXAMD64:\$LD_LIBRARY_PATH
+    prepend-path LD_LIBRARY_PATH  $PREFIX/lib/redistrib/lib_LINUXAMD64
 }


### PR DESCRIPTION
The variable LD_LIBRARY_PATH was not properly defined and it was overwriting the previous variable definition.