### PR TITLE
Add MotionCor3 v1.2.4 to run on GH nodes

### DIFF
--- a/EM/MotionCor3/build
+++ b/EM/MotionCor3/build
@@ -14,7 +14,28 @@ pbuild::configure() {
 
 pbuild::compile() {
     cd "$SRC_DIR"
-    make exe -f makefile11 CUDAHOME="$CUDA_HOME"
+
+    if [[ $(uname -m) == "aarch64" ]]; then
+        # Remove x86-only flags
+        find . -type f \( -iname 'makefile*' -o -iname '*.mk' \) \
+            -exec sed -i 's/-m64//g' {} +
+
+        # Optional: remove SSE/AVX flags too
+        find . -type f \( -iname 'makefile*' -o -iname '*.mk' \) \
+            -exec sed -i 's/-msse[^ ]*//g; s/-mavx[^ ]*//g' {} +
+    fi
+
+    # Clean old objects/libraries
+    find . -name '*.o' -delete
+    rm -f LibSrc/Lib/*.a
+
+    # Build dependent libraries
+    make -C TiffUtil
+    make -C LibSrc/Util
+    make -C LibSrc/Mrcfile
+
+    # Build MotionCor3
+    make -f makefile11 exe CUDAHOME="$CUDA_HOME"
 }
 
 pbuild::install() {

--- a/EM/MotionCor3/files/config.yaml
+++ b/EM/MotionCor3/files/config.yaml
@@ -7,13 +7,23 @@ MotionCor3:
     relstage: stable
 
   versions:
-    1.2.1:
+    1.2.4:
       variants:
         - overlay: Alps
+          target_cpus: [x86_64]
           systems: [.*.merlin7.psi.ch]
           relstage: stable
           build_requires:
             - gcc/12.3.0
-            - cuda/12.2.0
+            - cuda/12.8.1
           runtime_deps:
-            - cuda/12.2.0
+            - cuda/12.8.1
+        - overlay: Alps
+          target_cpus: [aarch64]
+          systems: [gpu0.*.merlin7.psi.ch]
+          relstage: stable
+          build_requires:
+            - gcc/12.3.0
+            - cuda/12.8.1
+          runtime_deps:
+            - cuda/12.8.1 


### PR DESCRIPTION
## Task
I've adapted the building to allow it to be compiled on GH nodes.

## Package description
Anisotropic correction of beam induced motion for cryo-electron microscopy and cryo-electron tomography images.

MotionCor3, an improved implementation of MotionCor2 with addition of CTF (Contrast Transfer Function) estimation, is a multi-GPU accelerated software package that enables single-pixel level correction of anisotropic beam induced sample motion for cryo-electron microscopy and cryo-electron tomography images. The iterative, patch-based motion detection combined with spatial and temporal constraints and dose weighting provides robust and accurate correction. By refining the measurement of early motion, MotionCor3 further improves correction on tilted samples. The efficiency achieved by multi-GPU acceleration and parallelization enables correction to keep pace with automated data collection. The recent addition of a very robust GPU-accelerated CTF estimation makes MotionCor3 more versatile in cryoEM and cryoET processing pipeline.

https://github.com/czimaginginstitute/MotionCor3

