### PR TITLE
Add refgenie v0.13.0

### DIFF
--- a/EM/refgenie/README.md
+++ b/EM/refgenie/README.md
@@ -1,0 +1,5 @@
+# refgenie
+
+Refgenie manages storage, access, and transfer of reference genome resources. It provides command-line and Python interfaces to download pre-built reference genome "assets", like indexes used by bioinformatics tools. It can also build assets for custom genome assemblies. Refgenie provides programmatic access to a standard genome folder structure, so software can swap from one genome to another.
+
+https://refgenie.databio.org/en/latest/

--- a/EM/refgenie/build
+++ b/EM/refgenie/build
@@ -1,0 +1,29 @@
+#!/usr/bin/env modbuild
+
+pbuild::configure() {
+    # Install Miniforge
+    mkdir -p "$PREFIX/miniforge"
+    wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O "$PREFIX/miniforge/miniforge.sh"
+    bash "$PREFIX/miniforge/miniforge.sh" -b -u -p "$PREFIX/miniforge/"
+
+    # Initialize mamba for script use
+    source "$PREFIX/miniforge/etc/profile.d/mamba.sh"
+
+    # Create the conda environment
+    mamba create -y --name "${P}_${V_PKG}"
+}
+
+pbuild::compile() {
+    :
+}
+
+pbuild::install() {
+    # Ensure mamba is initialized
+    source "$PREFIX/miniforge/etc/profile.d/mamba.sh"
+
+    # Activate the conda environment
+    mamba activate "${P}_${V_PKG}"
+
+    # Install refgenie 
+    mamba install bioconda::${P}=${V_PKG}
+}

--- a/EM/refgenie/files/config.yaml
+++ b/EM/refgenie/files/config.yaml
@@ -1,0 +1,19 @@
+---
+format: 1
+refgenie:
+  defaults:
+    group: EM
+    overlay: base
+    relstage: stable
+
+  versions:
+    0.13.0:
+      variants:
+        - overlay: Alps
+          target_cpus: [x86_64]
+          systems: [.*.merlin7.psi.ch]
+          relstage: stable
+        - overlay: Alps
+          target_cpus: [aarch64]
+          systems: [gpu0.*.merlin7.psi.ch]
+          relstage: stable

--- a/EM/refgenie/modulefile
+++ b/EM/refgenie/modulefile
@@ -1,0 +1,18 @@
+#%Module1.0
+
+module-whatis       "Refgenie creates a standardized folder structure for reference genome files and indexes"
+module-url          "https://refgenie.databio.org/en/latest/"
+module-license      "BSD-2-Clause license"
+module-maintainer   "João Pedro Agostinho de Sousa <joao.agostinho-de-sousa@psi.ch>"
+
+module-help         "
+Refgenie manages storage, access, and transfer of reference genome resources.
+It provides command-line and Python interfaces to download pre-built reference
+genome assets, like indexes used by bioinformatics tools. It can also build
+assets for custom genome assemblies. Refgenie provides programmatic access to a
+standard genome folder structure, so software can swap from one genome to
+another.
+"
+
+# Add conda env bin directory to PATH
+prepend-path PATH "${PREFIX}/miniforge/envs/${P}_${V_PKG}/bin"


### PR DESCRIPTION
Refgenie manages storage, access, and transfer of reference genome resources. It provides command-line and Python interfaces to download pre-built reference genome "assets", like indexes used by bioinformatics tools. It can also build assets for custom genome assemblies. Refgenie provides programmatic access to a standard genome folder structure, so software can swap from one genome to another.

https://refgenie.databio.org/en/latest/