### PR TITLE
Revert the python version to 3.12 to avoid SSL errors

### DIFF
--- a/EM/nf-core/build
+++ b/EM/nf-core/build
@@ -1,7 +1,7 @@
 #!/usr/bin/env modbuild
 
 # default Python version
-: "${PYTHON_VERSION:=3.14}"
+: "${PYTHON_VERSION:=3.12}"
 
 pbuild::configure() {
     # Install Miniforge
@@ -26,6 +26,9 @@ pbuild::install() {
 
     # Activate the conda environment
     mamba activate "${P}_${V_PKG}"
+
+    # Install CA tooling
+    mamba install -y ca-certificates certifi openssl
 
     # Install nf-core 
     pip install "${P}==${V_PKG}"


### PR DESCRIPTION
I've previously installed nf-core with python version 3.14 and I was repeatedly having issues with SSL errors. I tried to downgrade the python version and that worked well.