### PR TITLE
Fix model_angelo torch installation

### DIFF
--- a/EM/model_angelo/build
+++ b/EM/model_angelo/build
@@ -34,7 +34,7 @@ pbuild::install() {
     cd "$SRC_DIR"
 
     # Install torch
-    pip install "torch==${TORCH_VERSION}" torchvision
+    pip install "torch==${TORCH_VERSION}" torchvision --index-url https://download.pytorch.org/whl/cu129
 
     # Adapt pyhmmer to allow the installation in ARM architecture
     if [[ "$(uname -m)" == "aarch64" ]]; then

--- a/EM/model_angelo/files/config.yaml
+++ b/EM/model_angelo/files/config.yaml
@@ -18,7 +18,15 @@ model_angelo:
           target_cpus: [x86_64]
           systems: [.*.merlin7.psi.ch]
           relstage: stable
+          build_requires:
+            - cuda/12.9.1
+          runtime_deps:
+            - cuda/12.9.1
         - overlay: Alps
           target_cpus: [aarch64]
           systems: [gpu0.*.merlin7.psi.ch]
           relstage: stable
+          build_requires:
+            - cuda/12.9.1
+          runtime_deps:
+            - cuda/12.9.1

--- a/EM/model_angelo/modulefile
+++ b/EM/model_angelo/modulefile
@@ -14,3 +14,6 @@ construct 3D atomic models and identify proteins from cryo-electron microscopy
 
 # Add conda env bin directory to PATH
 prepend-path PATH "${PREFIX}/miniforge/envs/${P}_${V_PKG}/bin"
+
+# Add the directory of the pre-downloaded model weights
+setenv TORCH_HOME /data/project/cls/shared/models/model_angelo


### PR DESCRIPTION
The ModelAngelo module was only installing the cpu version of the python package torch. I've forced it to fetch the gpu version.