### PR TITLE
Update UCX and GDRCopy

### DIFF
--- a/Libraries/GDRCopy/files/config.yaml
+++ b/Libraries/GDRCopy/files/config.yaml
@@ -3,6 +3,7 @@ GDRCopy:
   defaults:
     group: Libraries
     relstage: stable
+    overlay: base
     compile_in_sourcetree: true
     docfiles:
       - LICENSE
@@ -28,7 +29,7 @@ GDRCopy:
           use_flags: [merlin7]
           build_requires: [cuda/13.2.1]
         - systems: [merlin-.*.psi.ch]
-          overlay: base
+          use_flags: [merlin6]
           build_requires: [cuda/13.2.1]
     2.5:
       config:
@@ -40,8 +41,6 @@ GDRCopy:
           use_flags: [merlin7]
           build_requires: [cuda/12.9.1]
         - systems: [merlin-.*.psi.ch]
-          overlay: merlin
-          use_overlays: [merlin]
           use_flags: [merlin6]
           build_requires: [cuda/12.9.1]
     2.4.4:

--- a/Libraries/ucx/files/config.yaml
+++ b/Libraries/ucx/files/config.yaml
@@ -34,13 +34,12 @@ ucx:
         - systems: [merlin-.*.psi.ch]
           relstage: unstable
           build_requires:
-            - hwloc/2.13.0
-            - patchelf/0.14.5
-            - knem/1.1.4
-            - xpmem/2.6.5
-          runtime_deps:
             - cuda/13.2.1
-            - GDRCopy/2.5
+            - GDRCopy/2.5.2
+            - hwloc/2.13.0
+            - knem/1.1.4
+            - patchelf/0.14.5
+            - xpmem/2.6.5
           configure_args+:
             - --with-rdmacm
             - --with-mlx5
@@ -57,12 +56,11 @@ ucx:
           group_deps:
             compiler: {gcc: [13.2.0]}
           build_requires:
-            - hwloc/2.12.0
-            - patchelf/0.14.5
-            - knem/1.1.4
-          runtime_deps:
             - cuda/12.9.1
             - GDRCopy/2.5
+            - hwloc/2.12.0
+            - knem/1.1.4
+            - patchelf/0.14.5
           configure_args+:
             - --with-rdmacm
             - --with-mlx5


### PR DESCRIPTION
- Fixes runtime dependencies for UCX
- Fixes overlay in use
- Updates UCX to be compiled with GDRCopy/2.5.2 (CUDA v13 supported) instead of GDRCopy/2.5 (only cuda v12 was supported)
- The full openmpi/5.0.10_slurm stack and its dependencies have been recompiled by using RHEL8, therefore, RHEL8 and RHEL9 are now supported (in the past it was compiled with RHEL9, making it unusable for RHEL8 systems).

closes: #957