### PR TITLE
add musl for rust and cargo usage

### DIFF
--- a/Programming/musl/build
+++ b/Programming/musl/build
@@ -1,0 +1,12 @@
+#!/usr/bin/env modbuild
+
+export LC_ALL=C
+
+pbuild::configure(){ :; }
+
+# Sometime I had issues with more then 4 parallel make jobs.
+pbuild::compile(){
+    echo -e "TARGET=x86_64-linux-musl\nOUTPUT=$PREFIX" > config.mak
+    ls -la
+    make -j4
+}

--- a/Programming/musl/files/config.yaml
+++ b/Programming/musl/files/config.yaml
@@ -1,0 +1,22 @@
+---
+format: 1
+musl:
+  defaults:
+    group: Programming
+    relstage: stable
+    compile_in_sourcetree: true
+
+  shasums:
+    musl-cross-make-2026-07-03.tar.gz: bb3fc7851088e1e5e1274ee56a0ab6ae176043d160fdf0b71027934b091f208a
+
+  versions:
+    1.2.6:
+      config:
+        urls:
+          - url: https://github.com/richfelker/musl-cross-make/archive/227df8b99103f9c59f6570babf892978e293082f.tar.gz
+            name: musl-cross-make-2026-07-03.tar.gz
+        relstage: unstable
+      variants:
+        - overlay: PSI
+          systems: [.*.merlin7.psi.ch]
+          target_cpus: [x86_64]

--- a/Programming/musl/modulefile
+++ b/Programming/musl/modulefile
@@ -1,0 +1,25 @@
+#%Module1.0
+
+module-whatis		"MUSL-gcc is a special compiler for producing static binaries"
+module-url		"https://www.musl-libc.org/"
+module-license		"MIT"
+module-maintainer	"Hans-Nikolai Viessmann <hans-nikolai.viessmann@psi.ch>"
+
+module-help	"
+musl provides consistent quality and implementation behavior from tiny embedded
+systems to full-fledged servers. Minimal machine-specific code means less
+chance of breakage on minority architectures and better success with “write
+once run everywhere” C development.
+"
+module-addgroup "Compiler"
+
+setenv		CC			$PREFIX/bin/x86_64-linux-musl-gcc
+setenv		CXX			$PREFIX/bin/x86_64-linux-musl-g++
+setenv		F77			$PREFIX/bin/x86_64-linux-musl-gfortran
+setenv		F90			$PREFIX/bin/x86_64-linux-musl-gfortran
+setenv		FC			$PREFIX/bin/x86_64-linux-musl-gfortran
+setenv		FORTRAN			$PREFIX/bin/x86_64-linux-musl-gfortran
+
+if { [file exist "/usr/lib/x86_64-linux-gnu"] } {
+	append-path LIBRARY_PATH	"/usr/lib/x86_64-linux-gnu"
+}


### PR DESCRIPTION
Adds module with musl-linked GCC (version 9.4.0) for creating static binaries using rust's cargo tool.