### PR TITLE
Modify submission scripts to allow overload and map by NUMA nodes

### DIFF
--- a/EM/relion/scripts/5.0.0-perf/CPU.sh
+++ b/EM/relion/scripts/5.0.0-perf/CPU.sh
@@ -13,7 +13,6 @@
 # extra4        XXXextra4XXX
 
 #SBATCH --job-name=r500perf-cpu
-#SBATCH --open-mode=append
 #SBATCH --clusters=merlin7
 #SBATCH --hint=nomultithread
 #SBATCH --export=NONE
@@ -49,6 +48,6 @@ export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 
 # Execute RELION
 mpirun -np "${SLURM_NTASKS}" \
-  --map-by node:PE=${SLURM_CPUS_PER_TASK} \
-  --bind-to core --report-bindings \
+  --map-by numa:PE=${SLURM_CPUS_PER_TASK} \
+  --bind-to core:overload-allowed --report-bindings \
   XXXcommandXXX

--- a/EM/relion/scripts/5.0.0-perf/GPU.sh
+++ b/EM/relion/scripts/5.0.0-perf/GPU.sh
@@ -14,7 +14,6 @@
 # extra5        XXXextra5XXX
 
 #SBATCH --job-name=r500perf-gpu
-#SBATCH --open-mode=append
 #SBATCH --clusters=gmerlin7
 #SBATCH --hint=nomultithread
 #SBATCH --export=NONE
@@ -60,6 +59,6 @@ export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 
 # Execute RELION
 mpirun -np "${SLURM_NTASKS}" \
-  --map-by node:PE=${SLURM_CPUS_PER_TASK} \
-  --bind-to core --report-bindings \
+  --map-by numa:PE=${SLURM_CPUS_PER_TASK} \
+  --bind-to core:overload-allowed --report-bindings \
   XXXcommandXXX

--- a/EM/relion/scripts/5.0.1/CPU.sh
+++ b/EM/relion/scripts/5.0.1/CPU.sh
@@ -13,7 +13,6 @@
 # extra4        XXXextra4XXX
 
 #SBATCH --job-name=r501-cpu
-#SBATCH --open-mode=append
 #SBATCH --clusters=merlin7
 #SBATCH --hint=nomultithread
 #SBATCH --export=NONE
@@ -45,6 +44,6 @@ export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 
 # Execute RELION
 mpirun -np "${SLURM_NTASKS}" \
-  --map-by node:PE=${SLURM_CPUS_PER_TASK} \
-  --bind-to core --report-bindings \
+  --map-by numa:PE=${SLURM_CPUS_PER_TASK} \
+  --bind-to core:overload-allowed --report-bindings \
   XXXcommandXXX

--- a/EM/relion/scripts/5.0.1/GPU.sh
+++ b/EM/relion/scripts/5.0.1/GPU.sh
@@ -14,7 +14,6 @@
 # extra5        XXXextra5XXX
 
 #SBATCH --job-name=r501-gpu
-#SBATCH --open-mode=append
 #SBATCH --clusters=gmerlin7
 #SBATCH --hint=nomultithread
 #SBATCH --export=NONE
@@ -56,6 +55,6 @@ export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 
 # Execute RELION
 mpirun -np "${SLURM_NTASKS}" \
-  --map-by node:PE=${SLURM_CPUS_PER_TASK} \
-  --bind-to core --report-bindings \
+  --map-by numa:PE=${SLURM_CPUS_PER_TASK} \
+  --bind-to core:overload-allowed --report-bindings \
   XXXcommandXXX


### PR DESCRIPTION
I've modified the mpirun command to allow the job to run even if SLURM allocates CPU in different sockets.

```bash
mpirun -np "${SLURM_NTASKS}" \
  --map-by numa:PE=${SLURM_CPUS_PER_TASK} \
  --bind-to core:overload-allowed --report-bindings \
  XXXcommandXXX
```