### PR TITLE
Add fpart v1.7.0

### DIFF
--- a/Tools/fpart/README.md
+++ b/Tools/fpart/README.md
@@ -1,0 +1,7 @@
+# fpart
+
+Fpart is a Filesystem partitioner. It helps you sort file trees and pack them into bags (called "partitions"). It is developed in C and available under the BSD license.
+
+Fpsync, a powerful file-migration tool is also provided.
+
+https://github.com/martymac/fpart

--- a/Tools/fpart/files/config.yaml
+++ b/Tools/fpart/files/config.yaml
@@ -1,18 +1,25 @@
 ---
+# yamllint disable rule:line-length
 format: 1
 fpart:
   defaults:
     group: Tools
     overlay: base
     relstage: stable
-    configure_with: autotools
-    build_variants: first_match
-    target_cpus: [x86_64]
-    systems: [rhel8]
-    docfiles: [COPYING, README.md, Changelog.md]
     urls:                                               
       - url: https://github.com/martymac/$P/archive/refs/tags/$P-${V_PKG}.tar.gz
+
   shasums:                                              
     fpart-1.7.0.tar.gz: e5f82dd90001ed53200b2383bcfd520b1d8ee06d6a2a75b39d37d68daef20c88
+
   versions:
     1.7.0:
+      variants:
+        - overlay: base
+          target_cpus: [x86_64]
+          systems: [.*.merlin7.psi.ch]
+          relstage: stable
+        - overlay: base
+          target_cpus: [aarch64]
+          systems: [gpu0.*.merlin7.psi.ch]
+          relstage: stable

--- a/Tools/fpart/modulefile
+++ b/Tools/fpart/modulefile
@@ -1,12 +1,11 @@
 #%Module1.0
 
-module-whatis		"Fpart is a Filesystem partitioner"
-module-url		"https://www.fpart.org/"
-module-license	 	"BSD 2 Clause"
-module-maintainer	"Hans-Nikolai Viessmann <hans-nikolai.viessmann@psi.ch"
-
-module-help	"
-Fpart is a Filesystem partitioner. It helps you sort file trees and pack them into bags (called partitions). It is developed in C and available under the BSD license.
-
-Fpsync, a powerful file-migration tool is also provided. See https://www.fpart.org/ for more details and examples.
+module-whatis       "Fpart is a Filesystem partitioner"
+module-url          "https://github.com/martymac/fpart"
+module-license      "BSD-2-Clause license"
+module-maintainer   "João Pedro Agostinho de Sousa <joao.agostinho-de-sousa@psi.ch>"
+module-help "
+Fpart is a Filesystem partitioner. It helps you sort file trees and pack them
+into bags (called partitions). It is developed in C and available under the BSD
+license. Fpsync, a powerful file-migration tool is also provided.
 "


### PR DESCRIPTION
Fpart is a Filesystem partitioner. It helps you sort file trees and pack them into bags (called "partitions"). It is developed in C and available under the BSD license.

Fpsync, a powerful file-migration tool is also provided.

https://github.com/martymac/fpart