### PR TITLE
Add pytom-match-pick v0.13.2

### DIFF
--- a/EM/pytom-match-pick/README.md
+++ b/EM/pytom-match-pick/README.md
@@ -1,0 +1,5 @@
+# pytom-match-pick 
+
+GPU-accelerated template matching for cryo-electron tomography, originally developed in PyTom, as a standalone Python package that is run from the command line.
+
+https://sbc-utrecht.github.io/pytom-match-pick/

--- a/EM/pytom-match-pick/build
+++ b/EM/pytom-match-pick/build
@@ -1,0 +1,33 @@
+#!/usr/bin/env modbuild
+
+# default Python version
+: "${PYTHON_VERSION:=3.11}"
+
+pbuild::configure() {
+    # Install Miniforge
+    mkdir -p "$PREFIX/miniforge"
+    wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O "$PREFIX/miniforge/miniforge.sh"
+    bash "$PREFIX/miniforge/miniforge.sh" -b -u -p "$PREFIX/miniforge/"
+
+    # Initialize mamba for script use
+    source "$PREFIX/miniforge/etc/profile.d/mamba.sh"
+
+    # Create the conda environment
+    mamba create -y --name "${P}_${V_PKG}" "python=${PYTHON_VERSION}"
+}
+
+pbuild::compile() {
+    :
+}
+
+pbuild::install() {
+    # Ensure mamba is initialized
+    source "$PREFIX/miniforge/etc/profile.d/mamba.sh"
+
+    # Activate the conda environment
+    mamba activate "${P}_${V_PKG}"
+
+    # Install pytom-match-pick
+    pip install "pytom-match-pick[plotting]==${V_PKG}"
+}
+

--- a/EM/pytom-match-pick/files/config.yaml
+++ b/EM/pytom-match-pick/files/config.yaml
@@ -1,0 +1,29 @@
+---
+# yamllint disable rule:line-length
+format: 1
+pytom-match-pick:
+  defaults:
+    group: EM
+    overlay: base
+    relstage: stable
+
+  versions:
+    0.13.2:
+      variants:
+        - overlay: Alps
+          target_cpus: [x86_64]
+          systems: [.*.merlin7.psi.ch]
+          relstage: stable
+          build_requires:
+            - cuda/12.9.1
+          runtime_deps:
+            - cuda/12.9.1
+        - overlay: Alps
+          target_cpus: [aarch64]
+          systems: [gpu0.*.merlin7.psi.ch]
+          relstage: unstable
+          build_requires:
+            - cuda/12.9.1
+          runtime_deps:
+            - cuda/12.9.1
+ 

--- a/EM/pytom-match-pick/modulefile
+++ b/EM/pytom-match-pick/modulefile
@@ -1,0 +1,15 @@
+#%Module1.0
+
+module-whatis       "GPU-accelerated template matching for cryo-electron tomography"
+module-url          "https://sbc-utrecht.github.io/pytom-match-pick/"
+module-license      "GPL-2.0 license"
+module-maintainer   "João Pedro Agostinho de Sousa <joao.agostinho-de-sousa@psi.ch>"
+
+module-help "
+GPU-accelerated template matching for cryo-electron tomography, originally
+developed in PyTom, as a standalone Python package that is run from the command
+line.
+"
+
+# Add conda env bin directory to PATH
+prepend-path PATH "${PREFIX}/miniforge/envs/${P}_${V_PKG}/bin"


### PR DESCRIPTION
GPU-accelerated template matching for cryo-electron tomography, originally developed in PyTom, as a standalone Python package that is run from the command line.

https://sbc-utrecht.github.io/pytom-match-pick/