### PR TITLE
Add IsoNet2 v2.0.0-beta

### DIFF
--- a/EM/IsoNet2/README.md
+++ b/EM/IsoNet2/README.md
@@ -1,0 +1,5 @@
+# IsoNet2
+
+IsoNet2 is a deep-learning software package for simultaneous missing wedge correction, denoising, and CTF correction in cryo-electron tomography reconstructions using a deep neural network trained on information from the original tomogram(s). Compared to IsoNet1 (DOI: 10.1038/s41467-022-33957-8), IsoNet2 produces tomograms with higher resolution and less noise in roughly a tenth of the time. The software requires full tomograms or even/odd paired tomograms as input. Paired tomograms for Noise2Noise training can be split by either frame or tilt.
+
+https://github.com/IsoNet-cryoET/IsoNet2

--- a/EM/IsoNet2/build
+++ b/EM/IsoNet2/build
@@ -1,0 +1,40 @@
+#!/usr/bin/env modbuild
+
+pbuild::pre_configure() {
+    wget -P "$SRC_DIR" https://github.com/IsoNet-cryoET/${P}/releases/download/IsoNet-${V}/isoapp-1.0.0.AppImage
+}
+
+pbuild::configure() {
+    # Install Miniforge
+    mkdir -p "$PREFIX/miniforge"
+    wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O "$PREFIX/miniforge/miniforge.sh"
+    bash "$PREFIX/miniforge/miniforge.sh" -b -u -p "$PREFIX/miniforge/"
+
+    # Initialize mamba for script use
+    source "$PREFIX/miniforge/etc/profile.d/mamba.sh"
+
+    # Create the conda environment
+    mamba env create -y --name "${P}_${V_PKG}" -f "$BUILDBLOCK_DIR/env/${V}/isonet2_environment.yml"
+}
+
+pbuild::compile() {
+    :
+}
+
+pbuild::install() {
+    # Ensure mamba is initialized
+    source "$PREFIX/miniforge/etc/profile.d/mamba.sh"
+
+    # Activate the conda environment
+    export IFS=' '
+    mamba activate "${P}_${V_PKG}"
+
+    # Copy the IsoNet scripts to PREFIX
+    cp -r "$SRC_DIR/IsoNet" "$PREFIX"
+    cp "$SRC_DIR/isoapp-1.0.0.AppImage" "$PREFIX/IsoNet/bin/IsoNet2"
+    chmod +x "$PREFIX/IsoNet/bin/IsoNet2"
+    ln -s "$PREFIX/IsoNet/bin" "$PREFIX/bin" 
+    ./$PREFIX/bin/IsoNet2 --appimage-extract
+    ln -s "$PREFIX/bin/squashfs-root/AppRun" "$PREFIX/bin/IsoNet2"
+}
+

--- a/EM/IsoNet2/env/2.0.0-beta/isonet2_environment.yml
+++ b/EM/IsoNet2/env/2.0.0-beta/isonet2_environment.yml
@@ -1,0 +1,111 @@
+channels:
+  - pytorch
+  - nvidia
+  - conda-forge
+dependencies:
+  # --- Conda Packages ---
+  - python=3.10
+  - pip
+
+  # PyTorch Core
+  - pytorch
+  - torchvision
+  - torchaudio
+  - pytorch-cuda
+
+  # Core PyTorch Dependencies
+  - sympy
+  - jinja2
+  - filelock
+  - mpmath
+  - typing-extensions
+  
+  # Scientific/Binary Packages 
+  - numpy<2.0
+  - scipy
+  - pandas
+  - scikit-image
+  - pillow
+  - mrcfile
+  - pyarrow
+  - simpleitk
+  - tifffile
+  - matplotlib
+  - imageio
+  - networkx
+  
+  # Binaries
+  - graphviz
+  - python-blosc
+  - pyyaml
+
+  # --- Pip Packages ---
+  - pip:
+    - aiohttp==3.9.3
+    - aiosignal==1.3.1
+    - anyio==4.8.0
+    - async-timeout==4.0.3
+    - attrs==23.2.0
+    - backoff==2.2.1
+    - boto3==1.35.92
+    - botocore==1.35.92
+    - certifi==2022.12.7
+    - charset-normalizer==2.1.1
+    - click==8.1.7
+    - contourpy==1.2.0
+    - cryoet-data-portal==4.2.1
+    - cycler==0.12.1
+    - deepmerge==2.0
+    - einops==0.8.0
+    - exceptiongroup==1.2.2
+    - fidder==0.0.8
+    - fire==0.5.0
+    - focustools==0.2.3
+    - fonttools==4.46.0
+    - frozenlist==1.4.1
+    - fsspec==2024.10.0
+    - git-filter-repo==2.47.0
+    - gql==3.5.0
+    - graphql-core==3.2.5
+    - huggingface-hub==0.26.2
+    - humanize==4.11.0
+    - idna==3.4
+    - jmespath==1.0.1
+    - joblib==1.4.2
+    - kiwisolver==1.4.5
+    - lazy-loader==0.3
+    - lightning-utilities==0.10.1
+    - markdown-it-py==3.0.0
+    - markupsafe==2.1.3
+    - mdurl==0.1.2
+    - mrcz==0.5.7
+    - multidict==6.0.5
+    - ndjson==0.3.1
+    - numexpr==2.10.2
+    - packaging==24.0
+    - platformdirs==4.3.6
+    - pooch==1.8.2
+    - pygments==2.18.0
+    - pyparsing==3.1.1
+    - python-dateutil==2.8.2
+    - pytorch-lightning==2.1.4
+    - pytz==2024.1
+    - requests==2.28.1
+    - requests-toolbelt==1.0.0
+    - rich==13.7.1
+    - s3transfer==0.10.4
+    - safetensors==0.4.5
+    - shellingham==1.5.4
+    - six==1.16.0
+    - sniffio==1.3.1
+    - starfile==0.5.6
+    - strcase==1.0.0
+    - termcolor==2.4.0
+    - tiler==0.5.7
+    - timm==1.0.11
+    - torchmetrics==1.3.0.post0
+    - torchviz==0.0.2
+    - tqdm==4.66.1
+    - typer==0.12.3
+    - typer-config==1.4.2
+    - tzdata

--- a/EM/IsoNet2/files/config.yaml
+++ b/EM/IsoNet2/files/config.yaml
@@ -1,0 +1,32 @@
+---
+# yamllint disable rule:line-length
+format: 1
+IsoNet2:
+  defaults:
+    group: EM
+    overlay: base
+    relstage: stable
+    urls:
+      - url: https://github.com/IsoNet-cryoET/${P}/archive/refs/tags/IsoNet-${V}.tar.gz
+
+  shasums:
+    IsoNet-2.0.0-beta.tar.gz: 8c35ce6315de9e29dc6a7b8f6f7352a936b16f54759e8427a655f6c9233a0ec8 
+
+  versions:
+    2.0.0-beta:
+      variants:
+        - overlay: Alps
+          systems: [.*.merlin7.psi.ch]
+          relstage: stable
+          build_requires:
+            - cuda/12.9.1
+          runtime_deps:
+            - cuda/12.9.1
+        - overlay: Alps
+          target_cpus: [aarch64]
+          systems: [gpu0.*.merlin7.psi.ch]
+          relstage: stable
+          build_requires:
+            - cudatoolkit/24.3_11.8
+          runtime_deps:
+            - cudatoolkit/24.3_11.8

--- a/EM/IsoNet2/modulefile
+++ b/EM/IsoNet2/modulefile
@@ -1,0 +1,23 @@
+#%Module1.0
+
+module-whatis       "Isotropic Reconstruction of Electron Tomograms with Deep Learning Version 2"
+module-url          "https://github.com/IsoNet-cryoET/IsoNet2"
+module-license      "GPL-3.0 license"
+module-maintainer   "João Pedro Agostinho de Sousa <joao.agostinho-de-sousa@psi.ch>"
+
+module-help         "
+IsoNet2 is a deep-learning software package for simultaneous missing wedge
+correction, denoising, and CTF correction in cryo-electron tomography
+reconstructions using a deep neural network trained on information from the
+original tomogram(s). Compared to IsoNet1 (DOI: 10.1038/s41467-022-33957-8),
+IsoNet2 produces tomograms with higher resolution and less noise in roughly a
+tenth of the time. The software requires full tomograms or even/odd paired
+tomograms as input. Paired tomograms for Noise2Noise training can be split by
+either frame or tilt.
+"
+
+# Add conda env bin directory to PATH
+prepend-path PATH "${PREFIX}/miniforge/envs/${P}_${V_PKG}/bin"
+
+# Add IsoNet2 repository to PYTHONPATH
+prepend-path PYTHONPATH "${PREFIX}"


### PR DESCRIPTION
IsoNet2 is a deep-learning software package for simultaneous missing wedge correction, denoising, and CTF correction in cryo-electron tomography reconstructions using a deep neural network trained on information from the original tomogram(s). Compared to IsoNet1 (DOI: 10.1038/s41467-022-33957-8), IsoNet2 produces tomograms with higher resolution and less noise in roughly a tenth of the time. The software requires full tomograms or even/odd paired tomograms as input. Paired tomograms for Noise2Noise training can be split by either frame or tilt.

https://github.com/IsoNet-cryoET/IsoNet2