### PR TITLE
Added cuda as a dependency

### DIFF
--- a/EM/amber/files/config.yaml
+++ b/EM/amber/files/config.yaml
@@ -16,10 +16,12 @@ amber:
           build_requires:
             - gcc/12.3.0
             - mpich/4.3.1
+            - cuda/12.9.1
           relstage: stable
           runtime_deps:
             - gcc/12.3.0
             - mpich/4.3.1
+            - cuda/12.9.1
         - overlay: Alps
           target_cpus: [aarch64]
           systems: [gpu0.*.merlin7.psi.ch]
@@ -27,6 +29,8 @@ amber:
           build_requires:
             - gcc/12.3.0
             - mpich/4.3.1
+            - cuda/12.9.1
           runtime_deps:
             - gcc/12.3.0
             - mpich/4.3.1
+            - cuda/12.9.1


### PR DESCRIPTION
Added cuda as a dependency because in the CPU nodes it is not loaded by default when loading mpich/4.3.1