### PR TITLE
Add ambertools v26

### DIFF
--- a/EM/ambertools/README.md
+++ b/EM/ambertools/README.md
@@ -1,0 +1,7 @@
+# AmberTools
+
+AmberTools consists of several independently developed packages that work well by themselves, and with Amber26. The suite can also be used to carry out complete molecular dynamics simulations, with either explicit water or generalized Born solvent models.
+
+https://ambermd.org
+
+It's required to first download the installation file and store it in the directory ${BUILDBLOCK_DIR}/source/ambertools26.tar.bz2

--- a/EM/ambertools/build
+++ b/EM/ambertools/build
@@ -1,0 +1,91 @@
+#!/usr/bin/env modbuild
+
+# default Python version
+: "${PYTHON_VERSION:=3.12}"
+
+pbuild::prep() {
+    case "${V}" in
+        26)
+            # v26 requires CUDA < 12.9
+            module switch cuda/12.8.1
+            ;;
+    esac
+}
+
+pbuild::configure() {
+
+    # ------------------------------------------------
+    # Conda environment
+    # ------------------------------------------------
+    # Install Miniforge
+    mkdir -p "$PREFIX/miniforge"
+    wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O "$PREFIX/miniforge/miniforge.sh"
+    bash "$PREFIX/miniforge/miniforge.sh" -b -u -p "$PREFIX/miniforge/"
+
+    # Initialize mamba for script use
+    source "$PREFIX/miniforge/etc/profile.d/mamba.sh"
+
+    # Create the conda environment
+    mamba create -y --name "${P}_${V_PKG}" "python=${PYTHON_VERSION}"
+
+    # Activate the conda environment
+    mamba activate "${P}_${V_PKG}"
+
+    # Install biopython from conda-forge
+    mamba install -y conda-forge::biopython
+
+    # Install python dependencies
+    pip install "setuptools<69"
+
+    pip install \
+    numpy \
+    scipy \
+    matplotlib \
+    cython \
+    tk \
+    libpython \
+    pandas \
+    numba \
+    gemmi \
+    Bio \
+    rich \
+    freesasa \
+    scikit-learn \
+    sympy \
+    pydantic \
+    psutil \
+    networkx
+
+    # ------------------------------------------------
+    # CMake
+    # ------------------------------------------------
+    tar -xjf "${BUILDBLOCK_DIR}/source/ambertools26.tar.bz2" \
+        -C "${SRC_DIR}" \
+        --strip-components=1
+
+    cd "${SRC_DIR}/build"
+
+    cmake "${SRC_DIR}" \
+        -DCOMPILER=GNU \
+        -Wno-dev \
+        -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+        -DPYTHON_EXECUTABLE="$(which python3)" \
+        -DCMAKE_INSTALL_RPATH="/opt/psi/Programming/cuda/${CUDA_VERSION}/lib64" \
+        -DCMAKE_BUILD_RPATH="/opt/psi/Programming/cuda/${CUDA_VERSION}/lib64" \
+        -DCHECK_UPDATES=FALSE \
+        -DMPI=TRUE \
+        -DCUDA=TRUE \
+        -DINSTALL_TESTS=TRUE \
+        -DDOWNLOAD_MINICONDA=FALSE \
+        -DOPENMP=TRUE \
+        -DNCCL=FALSE
+}
+
+pbuild::compile() {
+    cmake --build "${SRC_DIR}/build" --parallel
+}
+
+pbuild::install() {
+    cmake --install "${SRC_DIR}/build"
+}
+

--- a/EM/ambertools/files/config.yaml
+++ b/EM/ambertools/files/config.yaml
@@ -1,0 +1,40 @@
+---
+# yamllint disable rule:line-length
+format: 1
+ambertools:
+  defaults:
+    group: EM 
+    overlay: base
+    relstage: stable
+
+  versions:
+    26:
+      variants:
+        - overlay: Alps
+          target_cpus: [x86_64]
+          systems: [.*.merlin7.psi.ch]
+          build_requires:
+            - gcc/12.3.0
+            - mpich/4.3.1
+            - cuda/12.9.1
+            - Python/3.10.16
+          relstage: stable
+          runtime_deps:
+            - gcc/12.3.0
+            - mpich/4.3.1
+            - cuda/12.9.1
+            - Python/3.10.16
+        - overlay: Alps
+          target_cpus: [aarch64]
+          systems: [gpu0.*.merlin7.psi.ch]
+          relstage: unstable
+          build_requires:
+            - gcc/12.3.0
+            - mpich/4.3.1
+            - cuda/12.9.1
+            - Python/3.10.13
+          runtime_deps:
+            - gcc/12.3.0
+            - mpich/4.3.1
+            - cuda/12.9.1
+            - Python/3.10.13

--- a/EM/ambertools/modulefile
+++ b/EM/ambertools/modulefile
@@ -1,0 +1,18 @@
+#%Module1.0
+
+module-whatis       "Suite of programs used to prepare, run, and analyze molecular dynamics (MD) simulations"
+module-url          "https://ambermd.org"
+module-license      "GNU General Public License"
+module-maintainer   "João Pedro Agostinho de Sousa <joao.agostinho-de-sousa@psi.ch>"
+module-help "
+AmberTools consists of several independently developed packages that work well
+by themselves, and with Amber26. The suite can also be used to carry out
+complete molecular dynamics simulations, with either explicit water or
+generalized Born solvent models.
+"
+
+# Version 26 requires cuda version <12.9
+if { ${V_PKG} == "26" } {
+  module switch cuda cuda/12.8.1
+}
+


### PR DESCRIPTION
AmberTools consists of several independently developed packages that work well by themselves, and with Amber26. The suite can also be used to carry out complete molecular dynamics simulations, with either explicit water or generalized Born solvent models.

https://ambermd.org

It's required to first download the installation file and store it in the directory ${BUILDBLOCK_DIR}/source/ambertools26.tar.bz2